### PR TITLE
Add WooCommerce customizations plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Il-Giardino-Segreto
+# Il Giardino Segreto – Personalizzazioni WooCommerce
+
+Questo repository contiene il plugin WordPress **IGS Ecommerce Customizations**, creato per raggruppare le personalizzazioni più richieste per l'ecommerce de Il Giardino Segreto. Il plugin permette di mantenere gli snippet in un unico punto, facilitandone l'attivazione e la manutenzione.
+
+## Funzionalità incluse
+
+- **Barra di avanzamento per la spedizione gratuita** con messaggi personalizzabili per carrello e checkout.
+- **Badge sconto** che mostra automaticamente la percentuale di riduzione sui prodotti in promozione.
+- **Badge "Novità"** per i prodotti pubblicati da poco con etichetta e durata configurabili.
+- **Campi aggiuntivi in checkout** per Codice Fiscale, Partita IVA e messaggio regalo, completi di salvataggio e visualizzazione su email e area amministrativa.
+
+Tutte le funzioni possono essere attivate o disattivate da una pagina impostazioni dedicata.
+
+## Installazione
+
+1. Scarica l'intero contenuto della cartella `igs-ecommerce-customizations` e comprimilo in un file `.zip`.
+2. Carica l'archivio dal pannello **Plugin → Aggiungi nuovo** di WordPress e attivalo.
+3. Vai in **WooCommerce → Personalizzazioni IGS** per configurare soglie, testi e preferenze.
+
+## Sviluppo
+
+- Il codice è organizzato in classi all'interno della cartella `includes/` per mantenere ogni funzionalità separata.
+- Gli stili front-end si trovano in `assets/css/frontend.css`.
+- Per aggiungere nuove personalizzazioni è sufficiente creare una nuova classe in `includes/` e inizializzarla nel bootstrap del plugin.
+
+Per contribuire, apri una pull request con una descrizione dettagliata delle modifiche e ricordati di eseguire un controllo sintattico PHP (`php -l`) prima di inviare.

--- a/igs-ecommerce-customizations/assets/css/frontend.css
+++ b/igs-ecommerce-customizations/assets/css/frontend.css
@@ -1,0 +1,46 @@
+.igs-progress-wrapper {
+    margin: 1rem 0 2rem;
+}
+
+.igs-progress {
+    background-color: #f1f1f1;
+    border-radius: 999px;
+    height: 12px;
+    overflow: hidden;
+    position: relative;
+}
+
+.igs-progress__bar {
+    background: linear-gradient(135deg, #6ab04c 0%, #badc58 100%);
+    border-radius: 999px;
+    display: block;
+    height: 100%;
+    transition: width 0.4s ease;
+}
+
+.igs-badge {
+    background-color: #1e3799;
+    border-radius: 2px;
+    color: #fff;
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    line-height: 1;
+    padding: 0.35rem 0.5rem;
+    text-transform: uppercase;
+    margin-right: 0.4rem;
+}
+
+.igs-badge--sale {
+    background-color: #eb2f06;
+}
+
+.igs-badge--new {
+    background-color: #0abde3;
+}
+
+.igs-badge--single {
+    margin-bottom: 1rem;
+    display: inline-block;
+}

--- a/igs-ecommerce-customizations/igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/igs-ecommerce-customizations.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name:       IGS Ecommerce Customizations
+ * Plugin URI:        https://example.com/
+ * Description:       Raccolta di personalizzazioni per Il Giardino Segreto su WooCommerce.
+ * Version:           1.0.0
+ * Author:            Il Giardino Segreto
+ * Author URI:        https://example.com/
+ * Text Domain:       igs-ecommerce
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'IGS_ECOMMERCE_VERSION', '1.0.0' );
+define( 'IGS_ECOMMERCE_PLUGIN_FILE', __FILE__ );
+define( 'IGS_ECOMMERCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'IGS_ECOMMERCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+require_once IGS_ECOMMERCE_PLUGIN_DIR . 'includes/class-igs-plugin.php';
+
+add_action( 'plugins_loaded', static function () {
+    \IGS_Ecommerce_Customizations\Plugin::instance()->init();
+} );

--- a/igs-ecommerce-customizations/includes/class-igs-checkout-fields.php
+++ b/igs-ecommerce-customizations/includes/class-igs-checkout-fields.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Additional checkout fields feature.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS_Ecommerce_Customizations;
+
+use WC_Order;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Add fiscal code, VAT and gift message fields to checkout.
+ */
+class Checkout_Fields {
+    /**
+     * Settings handler.
+     *
+     * @var Settings
+     */
+    private $settings;
+
+    /**
+     * Constructor.
+     */
+    public function __construct( Settings $settings ) {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Register hooks.
+     */
+    public function init(): void {
+        add_filter( 'woocommerce_checkout_fields', [ $this, 'register_fields' ] );
+        add_action( 'woocommerce_checkout_process', [ $this, 'validate_fields' ] );
+        add_action( 'woocommerce_checkout_update_order_meta', [ $this, 'save_fields' ] );
+        add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'render_admin_data' ] );
+        add_filter( 'woocommerce_email_order_meta_fields', [ $this, 'append_email_meta' ], 10, 3 );
+    }
+
+    /**
+     * Add fields to checkout form.
+     *
+     * @param array<string, mixed> $fields Checkout fields.
+     * @return array<string, mixed>
+     */
+    public function register_fields( array $fields ): array {
+        $fields['billing']['billing_codice_fiscale'] = [
+            'type'        => 'text',
+            'label'       => __( 'Codice Fiscale', 'igs-ecommerce' ),
+            'placeholder' => __( 'Inserisci il tuo Codice Fiscale', 'igs-ecommerce' ),
+            'required'    => (bool) $this->settings->get( 'require_codice_fiscale', 1 ),
+            'class'       => [ 'form-row-wide' ],
+            'priority'    => 120,
+        ];
+
+        $fields['billing']['billing_partita_iva'] = [
+            'type'        => 'text',
+            'label'       => __( 'Partita IVA', 'igs-ecommerce' ),
+            'placeholder' => __( 'Inserisci la Partita IVA', 'igs-ecommerce' ),
+            'required'    => (bool) $this->settings->get( 'require_partita_iva', 0 ),
+            'class'       => [ 'form-row-wide' ],
+            'priority'    => 121,
+        ];
+
+        if ( $this->settings->is_enabled( 'gift_message' ) ) {
+            $fields['order']['igs_gift_message'] = [
+                'type'        => 'textarea',
+                'label'       => __( 'Messaggio regalo', 'igs-ecommerce' ),
+                'placeholder' => __( 'Scrivi un messaggio da includere nel pacco (facoltativo)', 'igs-ecommerce' ),
+                'required'    => false,
+                'class'       => [ 'form-row-wide' ],
+                'priority'    => 22,
+            ];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Validate custom fields.
+     */
+    public function validate_fields(): void {
+        $requires_cf  = (bool) $this->settings->get( 'require_codice_fiscale', 1 );
+        $requires_piva = (bool) $this->settings->get( 'require_partita_iva', 0 );
+
+        $codice_fiscale = isset( $_POST['billing_codice_fiscale'] ) ? wc_clean( wp_unslash( $_POST['billing_codice_fiscale'] ) ) : '';
+        $partita_iva    = isset( $_POST['billing_partita_iva'] ) ? wc_clean( wp_unslash( $_POST['billing_partita_iva'] ) ) : '';
+        $gift_message   = isset( $_POST['igs_gift_message'] ) ? wc_clean( wp_unslash( $_POST['igs_gift_message'] ) ) : '';
+
+        if ( $requires_cf && empty( $codice_fiscale ) ) {
+            wc_add_notice( __( 'Il Codice Fiscale è obbligatorio.', 'igs-ecommerce' ), 'error' );
+        }
+
+        if ( ! empty( $codice_fiscale ) && ! $this->is_valid_codice_fiscale( $codice_fiscale ) ) {
+            wc_add_notice( __( 'Il Codice Fiscale non sembra valido.', 'igs-ecommerce' ), 'error' );
+        }
+
+        if ( $requires_piva && empty( $partita_iva ) ) {
+            wc_add_notice( __( 'La Partita IVA è obbligatoria.', 'igs-ecommerce' ), 'error' );
+        }
+
+        if ( ! empty( $partita_iva ) && ! preg_match( '/^[0-9]{11}$/', $partita_iva ) ) {
+            wc_add_notice( __( 'La Partita IVA deve contenere 11 cifre.', 'igs-ecommerce' ), 'error' );
+        }
+
+        if ( $this->settings->is_enabled( 'gift_message' ) && ! empty( $gift_message ) ) {
+            $max = max( 20, (int) $this->settings->get( 'gift_message_max_length', 180 ) );
+            if ( strlen( $gift_message ) > $max ) {
+                wc_add_notice(
+                    sprintf(
+                        /* translators: %d: max length */
+                        __( 'Il messaggio regalo può contenere al massimo %d caratteri.', 'igs-ecommerce' ),
+                        $max
+                    ),
+                    'error'
+                );
+            }
+        }
+    }
+
+    /**
+     * Save custom field values to order meta.
+     */
+    public function save_fields( int $order_id ): void {
+        if ( isset( $_POST['billing_codice_fiscale'] ) ) {
+            update_post_meta( $order_id, '_billing_codice_fiscale', sanitize_text_field( wp_unslash( $_POST['billing_codice_fiscale'] ) ) );
+        }
+
+        if ( isset( $_POST['billing_partita_iva'] ) ) {
+            update_post_meta( $order_id, '_billing_partita_iva', sanitize_text_field( wp_unslash( $_POST['billing_partita_iva'] ) ) );
+        }
+
+        if ( isset( $_POST['igs_gift_message'] ) ) {
+            update_post_meta( $order_id, '_igs_gift_message', sanitize_textarea_field( wp_unslash( $_POST['igs_gift_message'] ) ) );
+        }
+    }
+
+    /**
+     * Display data in admin order screen.
+     */
+    public function render_admin_data( WC_Order $order ): void {
+        $codice_fiscale = $order->get_meta( '_billing_codice_fiscale' );
+        $partita_iva    = $order->get_meta( '_billing_partita_iva' );
+        $gift_message   = $order->get_meta( '_igs_gift_message' );
+
+        if ( $codice_fiscale ) {
+            printf( '<p><strong>%s:</strong> %s</p>', esc_html__( 'Codice Fiscale', 'igs-ecommerce' ), esc_html( $codice_fiscale ) );
+        }
+
+        if ( $partita_iva ) {
+            printf( '<p><strong>%s:</strong> %s</p>', esc_html__( 'Partita IVA', 'igs-ecommerce' ), esc_html( $partita_iva ) );
+        }
+
+        if ( $gift_message ) {
+            printf( '<p><strong>%s:</strong> %s</p>', esc_html__( 'Messaggio regalo', 'igs-ecommerce' ), esc_html( $gift_message ) );
+        }
+    }
+
+    /**
+     * Append metadata to customer emails.
+     *
+     * @param array<string, array<string, string>> $fields Fields.
+     * @param bool                                 $sent_to_admin Whether sent to admin.
+     * @param WC_Order                              $order Order object.
+     * @return array<string, array<string, string>>
+     */
+    public function append_email_meta( array $fields, bool $sent_to_admin, WC_Order $order ): array {
+        $codice_fiscale = $order->get_meta( '_billing_codice_fiscale' );
+        $partita_iva    = $order->get_meta( '_billing_partita_iva' );
+        $gift_message   = $order->get_meta( '_igs_gift_message' );
+
+        if ( $codice_fiscale ) {
+            $fields['billing_codice_fiscale'] = [
+                'label' => __( 'Codice Fiscale', 'igs-ecommerce' ),
+                'value' => $codice_fiscale,
+            ];
+        }
+
+        if ( $partita_iva ) {
+            $fields['billing_partita_iva'] = [
+                'label' => __( 'Partita IVA', 'igs-ecommerce' ),
+                'value' => $partita_iva,
+            ];
+        }
+
+        if ( $gift_message ) {
+            $fields['igs_gift_message'] = [
+                'label' => __( 'Messaggio regalo', 'igs-ecommerce' ),
+                'value' => $gift_message,
+            ];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Validate Italian Codice Fiscale with basic pattern.
+     */
+    private function is_valid_codice_fiscale( string $value ): bool {
+        $value = strtoupper( $value );
+
+        if ( preg_match( '/^[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9]{3}[A-Z]$/', $value ) ) {
+            return true;
+        }
+
+        return preg_match( '/^[0-9]{11}$/', $value ) === 1; // Accept numeric temporary codes.
+    }
+}

--- a/igs-ecommerce-customizations/includes/class-igs-free-shipping-progress.php
+++ b/igs-ecommerce-customizations/includes/class-igs-free-shipping-progress.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Free shipping progress bar feature.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS_Ecommerce_Customizations;
+
+use WC;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Display dynamic notice with progress towards free shipping.
+ */
+class Free_Shipping_Progress {
+    /**
+     * Settings instance.
+     *
+     * @var Settings
+     */
+    private $settings;
+
+    /**
+     * Constructor.
+     */
+    public function __construct( Settings $settings ) {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Hook feature into WooCommerce.
+     */
+    public function init(): void {
+        add_action( 'woocommerce_before_cart', [ $this, 'render_progress' ] );
+        add_action( 'woocommerce_checkout_before_order_review', [ $this, 'render_progress' ] );
+    }
+
+    /**
+     * Output notice and progress bar.
+     */
+    public function render_progress(): void {
+        if ( ! WC()->cart ) {
+            return;
+        }
+
+        $threshold = (float) $this->settings->get( 'free_shipping_threshold', 0 );
+
+        if ( $threshold <= 0 ) {
+            return;
+        }
+
+        $cart_total = (float) WC()->cart->get_cart_contents_total();
+
+        if ( 'incl' === get_option( 'woocommerce_tax_display_cart' ) ) {
+            $cart_total += (float) WC()->cart->get_cart_contents_tax();
+        }
+
+        $cart_total = max( 0, $cart_total );
+
+        $remaining = $threshold - $cart_total;
+        $remaining = max( 0, $remaining );
+
+        $percentage = $threshold > 0 ? min( 100, ( $cart_total / $threshold ) * 100 ) : 0;
+
+        $message = $remaining > 0
+            ? $this->replace_placeholders( $this->settings->get( 'free_shipping_goal_message' ), $remaining, $threshold, $cart_total )
+            : $this->replace_placeholders( $this->settings->get( 'free_shipping_success_message' ), 0, $threshold, $cart_total );
+
+        wc_print_notice( wp_kses_post( $message ), $remaining > 0 ? 'notice' : 'success' );
+
+        echo '<div class="igs-progress-wrapper" aria-hidden="true">';
+        printf(
+            '<div class="igs-progress"><span class="igs-progress__bar" style="width:%1$.2f%%"></span></div>',
+            $percentage
+        );
+        echo '</div>';
+    }
+
+    /**
+     * Replace message placeholders with dynamic values.
+     */
+    private function replace_placeholders( string $message, float $remaining, float $threshold, float $cart_total ): string {
+        $replacements = [
+            '{remaining}' => wc_price( $remaining ),
+            '{threshold}' => wc_price( $threshold ),
+            '{total}'     => wc_price( $cart_total ),
+        ];
+
+        return strtr( $message, $replacements );
+    }
+}

--- a/igs-ecommerce-customizations/includes/class-igs-new-badge.php
+++ b/igs-ecommerce-customizations/includes/class-igs-new-badge.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * New product badge feature.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS_Ecommerce_Customizations;
+
+use WC_Product;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Display "new" badge for recently published products.
+ */
+class New_Badge {
+    /**
+     * Settings handler.
+     *
+     * @var Settings
+     */
+    private $settings;
+
+    /**
+     * Constructor.
+     */
+    public function __construct( Settings $settings ) {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Attach hooks for output.
+     */
+    public function init(): void {
+        add_action( 'woocommerce_before_shop_loop_item_title', [ $this, 'render_loop_badge' ], 8 );
+        add_action( 'woocommerce_single_product_summary', [ $this, 'render_single_badge' ], 6 );
+    }
+
+    /**
+     * Render badge in product loop.
+     */
+    public function render_loop_badge(): void {
+        global $product;
+
+        if ( ! $product instanceof WC_Product ) {
+            return;
+        }
+
+        if ( ! $this->should_display_badge( $product ) ) {
+            return;
+        }
+
+        printf(
+            '<span class="igs-badge igs-badge--new">%s</span>',
+            esc_html( $this->settings->get( 'new_badge_label', __( 'Novità', 'igs-ecommerce' ) ) )
+        );
+    }
+
+    /**
+     * Render badge on single product page.
+     */
+    public function render_single_badge(): void {
+        global $product;
+
+        if ( ! $product instanceof WC_Product ) {
+            return;
+        }
+
+        if ( ! $this->should_display_badge( $product ) ) {
+            return;
+        }
+
+        printf(
+            '<span class="igs-badge igs-badge--new igs-badge--single">%s</span>',
+            esc_html( $this->settings->get( 'new_badge_label', __( 'Novità', 'igs-ecommerce' ) ) )
+        );
+    }
+
+    /**
+     * Check whether a product should show the new badge.
+     */
+    private function should_display_badge( WC_Product $product ): bool {
+        $days = max( 1, (int) $this->settings->get( 'new_badge_days', 30 ) );
+        $timestamp = $product->get_date_created() ? $product->get_date_created()->getTimestamp() : 0;
+
+        if ( ! $timestamp ) {
+            return false;
+        }
+
+        $limit = strtotime( sprintf( '-%d days', $days ) );
+
+        return $timestamp >= $limit;
+    }
+}

--- a/igs-ecommerce-customizations/includes/class-igs-plugin.php
+++ b/igs-ecommerce-customizations/includes/class-igs-plugin.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Core plugin bootstrap.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS_Ecommerce_Customizations;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/class-igs-settings.php';
+require_once __DIR__ . '/class-igs-free-shipping-progress.php';
+require_once __DIR__ . '/class-igs-sale-badge.php';
+require_once __DIR__ . '/class-igs-new-badge.php';
+require_once __DIR__ . '/class-igs-checkout-fields.php';
+
+/**
+ * Main Plugin class.
+ */
+class Plugin {
+    /**
+     * Singleton instance.
+     *
+     * @var Plugin|null
+     */
+    private static $instance = null;
+
+    /**
+     * Settings handler.
+     *
+     * @var Settings
+     */
+    private $settings;
+
+    /**
+     * Whether WooCommerce is loaded.
+     *
+     * @var bool
+     */
+    private $woocommerce_active = false;
+
+    /**
+     * Plugin features instances.
+     *
+     * @var array<string, object>
+     */
+    private $features = [];
+
+    /**
+     * Retrieve singleton instance.
+     */
+    public static function instance(): Plugin {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Prevent direct instantiation.
+     */
+    private function __construct() {}
+
+    /**
+     * Initialize plugin.
+     */
+    public function init(): void {
+        $this->woocommerce_active = class_exists( 'WooCommerce' );
+
+        if ( ! $this->woocommerce_active ) {
+            add_action( 'admin_notices', [ $this, 'render_missing_wc_notice' ] );
+            return;
+        }
+
+        $this->settings = new Settings();
+        $this->settings->register();
+
+        add_action( 'init', [ $this, 'load_textdomain' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+        $this->boot_features();
+    }
+
+    /**
+     * Load plugin text domain.
+     */
+    public function load_textdomain(): void {
+        load_plugin_textdomain( 'igs-ecommerce', false, dirname( plugin_basename( IGS_ECOMMERCE_PLUGIN_FILE ) ) . '/languages' );
+    }
+
+    /**
+     * Register frontend assets.
+     */
+    public function enqueue_assets(): void {
+        wp_register_style( 'igs-ecommerce-frontend', IGS_ECOMMERCE_PLUGIN_URL . 'assets/css/frontend.css', [], IGS_ECOMMERCE_VERSION );
+
+        $should_enqueue = false;
+
+        if ( $this->settings->is_enabled( 'free_shipping_progress' ) && ( is_cart() || is_checkout() ) ) {
+            $should_enqueue = true;
+        }
+
+        if ( $this->settings->is_enabled( 'discount_badge' ) || $this->settings->is_enabled( 'new_badge' ) ) {
+            $should_enqueue = true;
+        }
+
+        if ( $should_enqueue ) {
+            wp_enqueue_style( 'igs-ecommerce-frontend' );
+        }
+    }
+
+    /**
+     * Instantiate feature classes.
+     */
+    private function boot_features(): void {
+        if ( $this->settings->is_enabled( 'free_shipping_progress' ) ) {
+            $this->features['free_shipping_progress'] = new Free_Shipping_Progress( $this->settings );
+            $this->features['free_shipping_progress']->init();
+        }
+
+        if ( $this->settings->is_enabled( 'discount_badge' ) ) {
+            $this->features['sale_badge'] = new Sale_Badge( $this->settings );
+            $this->features['sale_badge']->init();
+        }
+
+        if ( $this->settings->is_enabled( 'new_badge' ) ) {
+            $this->features['new_badge'] = new New_Badge( $this->settings );
+            $this->features['new_badge']->init();
+        }
+
+        if ( $this->settings->is_enabled( 'checkout_fields' ) ) {
+            $this->features['checkout_fields'] = new Checkout_Fields( $this->settings );
+            $this->features['checkout_fields']->init();
+        }
+    }
+
+    /**
+     * Display admin notice when WooCommerce is missing.
+     */
+    public function render_missing_wc_notice(): void {
+        printf(
+            '<div class="notice notice-error"><p>%s</p></div>',
+            esc_html__( 'IGS Ecommerce Customizations richiede WooCommerce attivo per funzionare correttamente.', 'igs-ecommerce' )
+        );
+    }
+}

--- a/igs-ecommerce-customizations/includes/class-igs-sale-badge.php
+++ b/igs-ecommerce-customizations/includes/class-igs-sale-badge.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Discount badge customization.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS_Ecommerce_Customizations;
+
+use WC_Product;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Replace the default sale badge with discount percentage.
+ */
+class Sale_Badge {
+    /**
+     * Settings handler.
+     *
+     * @var Settings
+     */
+    private $settings;
+
+    /**
+     * Constructor.
+     */
+    public function __construct( Settings $settings ) {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Register filters.
+     */
+    public function init(): void {
+        add_filter( 'woocommerce_sale_flash', [ $this, 'render_badge' ], 10, 3 );
+    }
+
+    /**
+     * Render badge with percentage when possible.
+     *
+     * @param string      $html    Original HTML.
+     * @param WC_Product  $product Product object.
+     * @param string      $context Context.
+     * @return string
+     */
+    public function render_badge( string $html, $post, $product ): string {
+        if ( ! $product instanceof WC_Product ) {
+            return $html;
+        }
+
+        $regular_price = $this->get_regular_price( $product );
+        $sale_price    = $this->get_sale_price( $product );
+
+        if ( $regular_price <= 0 || $sale_price <= 0 || $sale_price >= $regular_price ) {
+            return sprintf( '<span class="igs-badge igs-badge--sale">%s</span>', esc_html__( 'In offerta', 'igs-ecommerce' ) );
+        }
+
+        $discount = round( ( 1 - ( $sale_price / $regular_price ) ) * 100 );
+        $discount = max( 1, $discount );
+
+        return sprintf(
+            '<span class="igs-badge igs-badge--sale">-%s%%</span>',
+            esc_html( $discount )
+        );
+    }
+
+    /**
+     * Retrieve base regular price.
+     */
+    private function get_regular_price( WC_Product $product ): float {
+        if ( $product->is_type( 'variable' ) ) {
+            return (float) $product->get_variation_regular_price( 'max', true );
+        }
+
+        if ( $product->is_type( 'grouped' ) ) {
+            $prices = [];
+            foreach ( $product->get_children() as $child_id ) {
+                $child = wc_get_product( $child_id );
+                if ( $child ) {
+                    $prices[] = (float) $child->get_regular_price();
+                }
+            }
+            return $prices ? max( $prices ) : 0.0;
+        }
+
+        return (float) $product->get_regular_price();
+    }
+
+    /**
+     * Retrieve sale price.
+     */
+    private function get_sale_price( WC_Product $product ): float {
+        if ( $product->is_type( 'variable' ) ) {
+            return (float) $product->get_variation_sale_price( 'min', true );
+        }
+
+        if ( $product->is_type( 'grouped' ) ) {
+            $prices = [];
+            foreach ( $product->get_children() as $child_id ) {
+                $child = wc_get_product( $child_id );
+                if ( $child && $child->is_on_sale() ) {
+                    $prices[] = (float) $child->get_sale_price();
+                }
+            }
+            return $prices ? min( $prices ) : 0.0;
+        }
+
+        return (float) $product->get_sale_price();
+    }
+}

--- a/igs-ecommerce-customizations/includes/class-igs-settings.php
+++ b/igs-ecommerce-customizations/includes/class-igs-settings.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Settings handler for the plugin.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS_Ecommerce_Customizations;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Manage plugin options and settings page.
+ */
+class Settings {
+    /**
+     * Option key.
+     */
+    private const OPTION_KEY = 'igs_ecommerce_customizations';
+
+    /**
+     * Default option values.
+     *
+     * @var array<string, mixed>
+     */
+    private $defaults = [
+        'enable_free_shipping_progress' => 1,
+        'free_shipping_threshold'       => 49.0,
+        'free_shipping_goal_message'    => 'Aggiungi {remaining} per ottenere la spedizione gratuita.',
+        'free_shipping_success_message' => 'Complimenti! Hai diritto alla spedizione gratuita.',
+        'enable_discount_badge'         => 1,
+        'enable_new_badge'              => 1,
+        'new_badge_days'                => 30,
+        'new_badge_label'               => 'Novità',
+        'enable_checkout_fields'        => 1,
+        'require_codice_fiscale'        => 1,
+        'require_partita_iva'           => 0,
+        'enable_gift_message'           => 1,
+        'gift_message_max_length'       => 180,
+    ];
+
+    /**
+     * Register hooks for settings screen.
+     */
+    public function register(): void {
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'admin_menu', [ $this, 'register_menu_page' ] );
+    }
+
+    /**
+     * Register option and fields.
+     */
+    public function register_settings(): void {
+        register_setting( self::OPTION_KEY, self::OPTION_KEY, [ $this, 'sanitize_settings' ] );
+
+        add_settings_section(
+            'igs_general_settings',
+            __( 'Impostazioni generali', 'igs-ecommerce' ),
+            null,
+            self::OPTION_KEY
+        );
+
+        $this->add_checkbox_field( 'enable_free_shipping_progress', __( 'Mostra barra progresso spedizione gratuita', 'igs-ecommerce' ) );
+        $this->add_number_field( 'free_shipping_threshold', __( 'Soglia spedizione gratuita (€)', 'igs-ecommerce' ), 0, 10000, 1 );
+        $this->add_text_field( 'free_shipping_goal_message', __( 'Messaggio per soglia non raggiunta', 'igs-ecommerce' ) );
+        $this->add_text_field( 'free_shipping_success_message', __( 'Messaggio quando la soglia è raggiunta', 'igs-ecommerce' ) );
+
+        $this->add_checkbox_field( 'enable_discount_badge', __( 'Mostra percentuale di sconto sui prodotti in offerta', 'igs-ecommerce' ) );
+
+        $this->add_checkbox_field( 'enable_new_badge', __( 'Mostra badge "Novità" per i nuovi prodotti', 'igs-ecommerce' ) );
+        $this->add_number_field( 'new_badge_days', __( 'Giorni in cui un prodotto è considerato nuovo', 'igs-ecommerce' ), 1, 120, 1 );
+        $this->add_text_field( 'new_badge_label', __( 'Etichetta badge novità', 'igs-ecommerce' ) );
+
+        $this->add_checkbox_field( 'enable_checkout_fields', __( 'Aggiungi campi extra al checkout', 'igs-ecommerce' ) );
+        $this->add_checkbox_field( 'require_codice_fiscale', __( 'Rendi obbligatorio il Codice Fiscale', 'igs-ecommerce' ) );
+        $this->add_checkbox_field( 'require_partita_iva', __( 'Rendi obbligatoria la Partita IVA', 'igs-ecommerce' ) );
+        $this->add_checkbox_field( 'enable_gift_message', __( 'Abilita messaggio regalo in checkout', 'igs-ecommerce' ) );
+        $this->add_number_field( 'gift_message_max_length', __( 'Numero massimo di caratteri per il messaggio regalo', 'igs-ecommerce' ), 50, 500, 10 );
+    }
+
+    /**
+     * Add submenu page under WooCommerce.
+     */
+    public function register_menu_page(): void {
+        $parent_slug = class_exists( 'WooCommerce' ) ? 'woocommerce' : 'options-general.php';
+
+        add_submenu_page(
+            $parent_slug,
+            __( 'Personalizzazioni IGS', 'igs-ecommerce' ),
+            __( 'Personalizzazioni IGS', 'igs-ecommerce' ),
+            'manage_woocommerce',
+            self::OPTION_KEY,
+            [ $this, 'render_settings_page' ]
+        );
+    }
+
+    /**
+     * Render admin settings page.
+     */
+    public function render_settings_page(): void {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Personalizzazioni IGS', 'igs-ecommerce' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( self::OPTION_KEY );
+                do_settings_sections( self::OPTION_KEY );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Sanitize option values.
+     *
+     * @param array<string, mixed> $input Raw option values.
+     * @return array<string, mixed>
+     */
+    public function sanitize_settings( array $input ): array {
+        $output = $this->get_all();
+
+        $checkboxes = [
+            'enable_free_shipping_progress',
+            'enable_discount_badge',
+            'enable_new_badge',
+            'enable_checkout_fields',
+            'require_codice_fiscale',
+            'require_partita_iva',
+            'enable_gift_message',
+        ];
+
+        foreach ( $checkboxes as $checkbox ) {
+            $output[ $checkbox ] = isset( $input[ $checkbox ] ) ? 1 : 0;
+        }
+
+        if ( isset( $input['free_shipping_threshold'] ) ) {
+            $output['free_shipping_threshold'] = max( 0, (float) $input['free_shipping_threshold'] );
+        }
+
+        if ( isset( $input['free_shipping_goal_message'] ) ) {
+            $output['free_shipping_goal_message'] = sanitize_text_field( $input['free_shipping_goal_message'] );
+        }
+
+        if ( isset( $input['free_shipping_success_message'] ) ) {
+            $output['free_shipping_success_message'] = sanitize_text_field( $input['free_shipping_success_message'] );
+        }
+
+        if ( isset( $input['new_badge_days'] ) ) {
+            $output['new_badge_days'] = max( 1, (int) $input['new_badge_days'] );
+        }
+
+        if ( isset( $input['new_badge_label'] ) ) {
+            $output['new_badge_label'] = sanitize_text_field( $input['new_badge_label'] );
+        }
+
+        if ( isset( $input['gift_message_max_length'] ) ) {
+            $output['gift_message_max_length'] = max( 20, (int) $input['gift_message_max_length'] );
+        }
+
+        return $output;
+    }
+
+    /**
+     * Retrieve full option array merged with defaults.
+     *
+     * @return array<string, mixed>
+     */
+    public function get_all(): array {
+        $saved = get_option( self::OPTION_KEY, [] );
+
+        return wp_parse_args( $saved, $this->defaults );
+    }
+
+    /**
+     * Retrieve specific option value.
+     *
+     * @param string     $key     Option key.
+     * @param mixed|null $default Default if not set.
+     * @return mixed
+     */
+    public function get( string $key, $default = null ) {
+        $options = $this->get_all();
+
+        return $options[ $key ] ?? $default;
+    }
+
+    /**
+     * Check if a feature is enabled.
+     */
+    public function is_enabled( string $feature ): bool {
+        return (bool) $this->get( 'enable_' . $feature, 0 );
+    }
+
+    /**
+     * Add checkbox field to settings page.
+     */
+    private function add_checkbox_field( string $key, string $label ): void {
+        add_settings_field(
+            $key,
+            esc_html( $label ),
+            function () use ( $key ) {
+                $value = (int) $this->get( $key );
+                printf(
+                    '<input type="checkbox" name="%1$s[%2$s]" value="1" %3$s />',
+                    esc_attr( self::OPTION_KEY ),
+                    esc_attr( $key ),
+                    checked( $value, 1, false )
+                );
+            },
+            self::OPTION_KEY,
+            'igs_general_settings'
+        );
+    }
+
+    /**
+     * Add number input to settings page.
+     */
+    private function add_number_field( string $key, string $label, int $min, int $max, int $step ): void {
+        add_settings_field(
+            $key,
+            esc_html( $label ),
+            function () use ( $key, $min, $max, $step ) {
+                $value = $this->get( $key );
+                printf(
+                    '<input type="number" name="%1$s[%2$s]" value="%3$s" min="%4$d" max="%5$d" step="%6$d" class="small-text" />',
+                    esc_attr( self::OPTION_KEY ),
+                    esc_attr( $key ),
+                    esc_attr( $value ),
+                    $min,
+                    $max,
+                    $step
+                );
+            },
+            self::OPTION_KEY,
+            'igs_general_settings'
+        );
+    }
+
+    /**
+     * Add text input to settings page.
+     */
+    private function add_text_field( string $key, string $label ): void {
+        add_settings_field(
+            $key,
+            esc_html( $label ),
+            function () use ( $key ) {
+                $value = $this->get( $key );
+                printf(
+                    '<input type="text" name="%1$s[%2$s]" value="%3$s" class="regular-text" />',
+                    esc_attr( self::OPTION_KEY ),
+                    esc_attr( $key ),
+                    esc_attr( $value )
+                );
+            },
+            self::OPTION_KEY,
+            'igs_general_settings'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add the new IGS Ecommerce Customizations plugin to group WooCommerce snippets in a single package
- register an options page to toggle free-shipping progress bar, discount badge, "new" badge, and checkout fields
- implement cart progress bar, product badges, checkout meta handling, and related frontend styles

## Testing
- find igs-ecommerce-customizations -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d3a470db08832fbd240ab38e2a3f4b