### PR TITLE
Fix portfolio display helper import

### DIFF
--- a/igs-ecommerce-customizations/includes/Frontend/class-portfolio-display.php
+++ b/igs-ecommerce-customizations/includes/Frontend/class-portfolio-display.php
@@ -7,6 +7,8 @@
 
 namespace IGS\Ecommerce\Frontend;
 
+use IGS\Ecommerce\Helpers;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }


### PR DESCRIPTION
## Summary
- add the missing `IGS\Ecommerce\Helpers` import to the portfolio display module so style URLs can be resolved without fatal errors

## Testing
- php -l igs-ecommerce-customizations/includes/Frontend/class-portfolio-display.php

------
https://chatgpt.com/codex/tasks/task_e_68d4265dca38832f9450ae56b3ac07ee