### PR TITLE
Sanitize booking modal configuration payload

### DIFF
--- a/igs-ecommerce-customizations/includes/Frontend/class-booking-modal.php
+++ b/igs-ecommerce-customizations/includes/Frontend/class-booking-modal.php
@@ -140,7 +140,13 @@ class Booking_Modal {
 
         echo '<fieldset class="igs-booking-form__group">';
         echo '<legend>' . esc_html__( 'Scegli la tua opzione', 'igs-ecommerce' ) . '</legend>';
-        echo '<div class="igs-booking-form__options" id="igs-booking-options" data-options=\'' . wp_json_encode( $options ) . '\'></div>';
+        $options_json = wp_json_encode( $options, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+
+        if ( false === $options_json ) {
+            $options_json = '[]';
+        }
+
+        echo '<div class="igs-booking-form__options" id="igs-booking-options" data-options="' . esc_attr( $options_json ) . '"></div>';
         echo '</fieldset>';
 
         echo '<fieldset class="igs-booking-form__group igs-booking-form__group--quantity">';
@@ -152,7 +158,7 @@ class Booking_Modal {
         echo '</div>';
         echo '</fieldset>';
 
-        echo '<div class="igs-booking-total" id="igs-booking-total">' . esc_html( wc_price( 0, [ 'decimals' => 2 ] ) ) . '</div>';
+        echo '<div class="igs-booking-total" id="igs-booking-total">' . wp_kses_post( wc_price( 0, [ 'decimals' => 2 ] ) ) . '</div>';
         echo '</form>';
 
         echo '<div class="igs-booking-modal__footer">';


### PR DESCRIPTION
## Summary
- escape the booking modal options payload before embedding it in the data attribute to prevent malformed markup with quotes
- render the initial booking total with `wp_kses_post()` so the WooCommerce formatted price remains intact

## Testing
- php -l igs-ecommerce-customizations/includes/Frontend/class-booking-modal.php

------
https://chatgpt.com/codex/tasks/task_e_68d429d1fafc832faa136e7c406ff4da