### PR TITLE
Handle contextual translations

### DIFF
--- a/igs-ecommerce-customizations/includes/class-translations.php
+++ b/igs-ecommerce-customizations/includes/class-translations.php
@@ -20,7 +20,7 @@ class Translations {
     /**
      * Cached translations grouped by locale.
      *
-     * @var array<string,array<string,string>>
+     * @var array<string,array{default: array<string,string>, contextual: array<string,array<string,string>>}>
      */
     private static array $cache = [];
 
@@ -29,6 +29,7 @@ class Translations {
      */
     public static function init(): void {
         add_filter( 'gettext', [ __CLASS__, 'filter_gettext' ], 5, 3 );
+        add_filter( 'gettext_with_context', [ __CLASS__, 'filter_gettext_with_context' ], 5, 4 );
     }
 
     /**
@@ -45,51 +46,96 @@ class Translations {
 
         $locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
 
-        if ( ! isset( self::$cache[ $locale ] ) ) {
-            self::$cache[ $locale ] = self::load_translations( $locale );
-        }
+        $catalogue = self::get_catalogue( $locale );
 
-        if ( isset( self::$cache[ $locale ][ $text ] ) ) {
-            return self::$cache[ $locale ][ $text ];
+        if ( isset( $catalogue['default'][ $text ] ) && '' !== $catalogue['default'][ $text ] ) {
+            return $catalogue['default'][ $text ];
         }
 
         return $translation;
     }
 
     /**
+     * Replace contextual strings using the PO catalogue.
+     */
+    public static function filter_gettext_with_context( string $translation, string $text, string $context, string $domain ): string {
+        if ( 'igs-ecommerce' !== $domain ) {
+            return $translation;
+        }
+
+        if ( $translation !== $text ) {
+            return $translation;
+        }
+
+        $locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+
+        $catalogue = self::get_catalogue( $locale );
+
+        if ( isset( $catalogue['contextual'][ $context ][ $text ] ) && '' !== $catalogue['contextual'][ $context ][ $text ] ) {
+            return $catalogue['contextual'][ $context ][ $text ];
+        }
+
+        return $translation;
+    }
+
+    /**
+     * Retrieve the cached catalogue for the current locale.
+     *
+     * @return array{default: array<string,string>, contextual: array<string,array<string,string>>}
+     */
+    private static function get_catalogue( string $locale ): array {
+        if ( ! isset( self::$cache[ $locale ] ) ) {
+            self::$cache[ $locale ] = self::load_translations( $locale );
+        }
+
+        return self::$cache[ $locale ];
+    }
+
+    /**
      * Parse the locale specific PO file.
      *
-     * @return array<string,string>
+     * @return array{default: array<string,string>, contextual: array<string,array<string,string>>}
      */
     private static function load_translations( string $locale ): array {
         $file = Helpers\path( 'languages/igs-ecommerce-' . $locale . '.po' );
 
         if ( ! is_readable( $file ) ) {
-            return [];
+            return [
+                'default'    => [],
+                'contextual' => [],
+            ];
         }
 
         $handle = fopen( $file, 'rb' );
 
         if ( ! $handle ) {
-            return [];
+            return [
+                'default'    => [],
+                'contextual' => [],
+            ];
         }
 
-        $entries = [];
+        $entries = [
+            'default'    => [],
+            'contextual' => [],
+        ];
         $msgid   = null;
         $msgstr  = '';
         $state   = null;
+        $context = null;
 
         while ( false !== ( $line = fgets( $handle ) ) ) {
             $line = rtrim( $line, "\r\n" );
 
             if ( '' === $line ) {
-                if ( null !== $msgid && '' !== $msgid ) {
-                    $entries[ $msgid ] = $msgstr;
+                if ( null !== $msgid ) {
+                    self::store_entry( $entries, $msgid, $msgstr, $context );
                 }
 
-                $msgid  = null;
-                $msgstr = '';
-                $state  = null;
+                $msgid   = null;
+                $msgstr  = '';
+                $state   = null;
+                $context = null;
                 continue;
             }
 
@@ -97,11 +143,13 @@ class Translations {
                 continue;
             }
 
-            if ( 0 === strpos( $line, 'msgid ' ) ) {
-                if ( null !== $msgid && '' !== $msgid ) {
-                    $entries[ $msgid ] = $msgstr;
-                }
+            if ( 0 === strpos( $line, 'msgctxt ' ) ) {
+                $context = self::parse_po_string( substr( $line, 8 ) );
+                $state   = 'msgctxt';
+                continue;
+            }
 
+            if ( 0 === strpos( $line, 'msgid ' ) ) {
                 $msgid  = self::parse_po_string( substr( $line, 6 ) );
                 $msgstr = '';
                 $state  = 'msgid';
@@ -115,7 +163,9 @@ class Translations {
             }
 
             if ( isset( $line[0] ) && '"' === $line[0] && $state ) {
-                if ( 'msgid' === $state && null !== $msgid ) {
+                if ( 'msgctxt' === $state && null !== $context ) {
+                    $context .= self::parse_po_string( $line );
+                } elseif ( 'msgid' === $state && null !== $msgid ) {
                     $msgid .= self::parse_po_string( $line );
                 } elseif ( 'msgstr' === $state ) {
                     $msgstr .= self::parse_po_string( $line );
@@ -125,11 +175,38 @@ class Translations {
 
         fclose( $handle );
 
-        if ( null !== $msgid && '' !== $msgid ) {
-            $entries[ $msgid ] = $msgstr;
+        if ( null !== $msgid ) {
+            self::store_entry( $entries, $msgid, $msgstr, $context );
         }
 
         return $entries;
+    }
+
+    /**
+     * Store a parsed PO entry into the catalogue buckets.
+     *
+     * @param array{default: array<string,string>, contextual: array<string,array<string,string>>} $entries Entries catalogue.
+     */
+    private static function store_entry( array &$entries, ?string $msgid, string $msgstr, ?string $context ): void {
+        if ( null === $msgid ) {
+            return;
+        }
+
+        if ( '' === $msgid && ( null === $context || '' === $context ) ) {
+            // Header entry, skip.
+            return;
+        }
+
+        if ( null !== $context && '' !== $context ) {
+            if ( ! isset( $entries['contextual'][ $context ] ) ) {
+                $entries['contextual'][ $context ] = [];
+            }
+
+            $entries['contextual'][ $context ][ $msgid ] = $msgstr;
+            return;
+        }
+
+        $entries['default'][ $msgid ] = $msgstr;
     }
 
     /**


### PR DESCRIPTION
## Summary
- expand the runtime translation cache to separate default and contextual entries
- load msgctxt blocks from PO files and honour them via the gettext_with_context filter

## Testing
- php -l igs-ecommerce-customizations/includes/class-translations.php

------
https://chatgpt.com/codex/tasks/task_e_68d42c3ff3e8832f82bab91a60d06c06