### PR TITLE
Fix booking modal handling for simple tours

### DIFF
--- a/igs-ecommerce-customizations/assets/js/booking-modal.js
+++ b/igs-ecommerce-customizations/assets/js/booking-modal.js
@@ -49,6 +49,8 @@ jQuery(function ($) {
         const variations = getVariations();
 
         optionsWrapper.empty();
+        selectedVariation = null;
+        unitPrice = 0;
 
         variations.forEach(function (variation, index) {
             const optionId = 'igs-variation-' + variation.id;
@@ -67,7 +69,7 @@ jQuery(function ($) {
 
             if (0 === index) {
                 input.prop('checked', true);
-                selectedVariation = variation.id;
+                selectedVariation = String(variation.id);
                 unitPrice = parseFloat(variation.price) || 0;
             }
 
@@ -89,7 +91,7 @@ jQuery(function ($) {
 
     function updateTotal() {
         const quantity = parseInt(quantityInput.val(), 10) || 1;
-        const total = Math.max(0, unitPrice) * quantity;
+        const total = Math.max(0, parseFloat(unitPrice) || 0) * quantity;
         totalEl.text(formatPrice(total));
     }
 
@@ -136,7 +138,7 @@ jQuery(function ($) {
     });
 
     optionsWrapper.on('change', 'input[name="variation_id"]', function () {
-        selectedVariation = $(this).val();
+        selectedVariation = String($(this).val());
         unitPrice = parseFloat($(this).data('price')) || 0;
         updateTotal();
     });
@@ -165,7 +167,7 @@ jQuery(function ($) {
 
         const variations = getVariations();
 
-        if (!selectedVariation && variations.length) {
+        if (variations.length && (null === selectedVariation || '' === selectedVariation)) {
             window.alert(settings.i18n.selectOption || '');
             return;
         }
@@ -176,7 +178,7 @@ jQuery(function ($) {
             action: 'igs_add_to_cart',
             nonce: settings.addToCartNonce,
             tour_id: settings.productId,
-            variation_id: selectedVariation,
+            variation_id: variations.length ? selectedVariation : '',
             quantity: quantityInput.val(),
         })
             .done(function (response) {

--- a/igs-ecommerce-customizations/igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/igs-ecommerce-customizations.php
@@ -3,7 +3,7 @@
  * Plugin Name:       IGS Ecommerce Customizations
  * Plugin URI:        https://example.com/
  * Description:       Raccolta di personalizzazioni per Il Giardino Segreto su WooCommerce.
- * Version:           1.2.0
+ * Version:           1.2.1
  * Author:            Il Giardino Segreto
  * Author URI:        https://example.com/
  * Text Domain:       igs-ecommerce
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'IGS_ECOMMERCE_VERSION', '1.2.0' );
+define( 'IGS_ECOMMERCE_VERSION', '1.2.1' );
 define( 'IGS_ECOMMERCE_FILE', __FILE__ );
 define( 'IGS_ECOMMERCE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IGS_ECOMMERCE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- reset the booking modal selection state on open and treat option identifiers as strings so simple tours with ID 0 can be booked
- guard against missing selections before checkout and fall back gracefully when no variations are available
- bump the plugin version to 1.2.1

## Testing
- php -l igs-ecommerce-customizations/igs-ecommerce-customizations.php

------
https://chatgpt.com/codex/tasks/task_e_68d4351d4ef8832f93df1a944d15cdb1