### PR TITLE
Add plural support to translation loader

### DIFF
--- a/igs-ecommerce-customizations/includes/Frontend/class-loop-display.php
+++ b/igs-ecommerce-customizations/includes/Frontend/class-loop-display.php
@@ -73,7 +73,8 @@ class Loop_Display {
             }
 
             if ( $duration ) {
-                echo '<div class="igs-loop-meta__duration">' . esc_html( $duration ) . ' ' . esc_html__( 'giorni', 'igs-ecommerce' ) . '</div>';
+                $label = _n( 'giorno', 'giorni', (int) $duration, 'igs-ecommerce' );
+                echo '<div class="igs-loop-meta__duration">' . esc_html( $duration ) . ' ' . esc_html( $label ) . '</div>';
             }
         }
 

--- a/igs-ecommerce-customizations/includes/Frontend/class-product-display.php
+++ b/igs-ecommerce-customizations/includes/Frontend/class-product-display.php
@@ -123,7 +123,8 @@ class Product_Display {
         echo '<div class="igs-tour-layout__installment">' . esc_html__( 'Pagamento a rate disponibile', 'igs-ecommerce' ) . '</div>';
 
         if ( $duration ) {
-            echo '<div class="igs-tour-layout__duration"><strong>' . esc_html( $duration ) . '</strong> ' . esc_html__( 'giorni', 'igs-ecommerce' ) . '</div>';
+            $label = _n( 'giorno', 'giorni', (int) $duration, 'igs-ecommerce' );
+            echo '<div class="igs-tour-layout__duration"><strong>' . esc_html( $duration ) . '</strong> ' . esc_html( $label ) . '</div>';
         }
 
         echo '<ul class="igs-tour-layout__services">';

--- a/igs-ecommerce-customizations/includes/class-translations.php
+++ b/igs-ecommerce-customizations/includes/class-translations.php
@@ -20,7 +20,14 @@ class Translations {
     /**
      * Cached translations grouped by locale.
      *
-     * @var array<string,array{default: array<string,string>, contextual: array<string,array<string,string>>}>
+     * @var array<string,array{
+     *     default: array<string,string>,
+     *     contextual: array<string,array<string,string>>,
+     *     plural: array<string,array<int,string>>,
+     *     contextual_plural: array<string,array<string,array<int,string>>>,
+     *     nplurals: int,
+     *     plural_rule: string,
+     * }
      */
     private static array $cache = [];
 
@@ -30,6 +37,8 @@ class Translations {
     public static function init(): void {
         add_filter( 'gettext', [ __CLASS__, 'filter_gettext' ], 5, 3 );
         add_filter( 'gettext_with_context', [ __CLASS__, 'filter_gettext_with_context' ], 5, 4 );
+        add_filter( 'ngettext', [ __CLASS__, 'filter_ngettext' ], 5, 5 );
+        add_filter( 'ngettext_with_context', [ __CLASS__, 'filter_ngettext_with_context' ], 5, 6 );
     }
 
     /**
@@ -79,9 +88,58 @@ class Translations {
     }
 
     /**
+     * Replace pluralised strings using the PO catalogue.
+     */
+    public static function filter_ngettext( string $translation, string $single, string $plural, int $number, string $domain ): string {
+        if ( 'igs-ecommerce' !== $domain ) {
+            return $translation;
+        }
+
+        $expected = ( 1 === (int) $number ) ? $single : $plural;
+
+        if ( $translation !== $expected ) {
+            return $translation;
+        }
+
+        $locale    = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+        $catalogue = self::get_catalogue( $locale );
+        $result    = self::lookup_plural( $catalogue, $single, $number, null );
+
+        return null !== $result ? $result : $translation;
+    }
+
+    /**
+     * Replace contextual plural strings using the PO catalogue.
+     */
+    public static function filter_ngettext_with_context( string $translation, string $single, string $plural, int $number, string $context, string $domain ): string {
+        if ( 'igs-ecommerce' !== $domain ) {
+            return $translation;
+        }
+
+        $expected = ( 1 === (int) $number ) ? $single : $plural;
+
+        if ( $translation !== $expected ) {
+            return $translation;
+        }
+
+        $locale    = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+        $catalogue = self::get_catalogue( $locale );
+        $result    = self::lookup_plural( $catalogue, $single, $number, $context );
+
+        return null !== $result ? $result : $translation;
+    }
+
+    /**
      * Retrieve the cached catalogue for the current locale.
      *
-     * @return array{default: array<string,string>, contextual: array<string,array<string,string>>}
+     * @return array{
+     *     default: array<string,string>,
+     *     contextual: array<string,array<string,string>>,
+     *     plural: array<string,array<int,string>>,
+     *     contextual_plural: array<string,array<string,array<int,string>>>,
+     *     nplurals: int,
+     *     plural_rule: string,
+     * }
      */
     private static function get_catalogue( string $locale ): array {
         if ( ! isset( self::$cache[ $locale ] ) ) {
@@ -94,7 +152,14 @@ class Translations {
     /**
      * Parse the locale specific PO file.
      *
-     * @return array{default: array<string,string>, contextual: array<string,array<string,string>>}
+     * @return array{
+     *     default: array<string,string>,
+     *     contextual: array<string,array<string,string>>,
+     *     plural: array<string,array<int,string>>,
+     *     contextual_plural: array<string,array<string,array<int,string>>>,
+     *     nplurals: int,
+     *     plural_rule: string,
+     * }
      */
     private static function load_translations( string $locale ): array {
         $file = Helpers\path( 'languages/igs-ecommerce-' . $locale . '.po' );
@@ -103,6 +168,10 @@ class Translations {
             return [
                 'default'    => [],
                 'contextual' => [],
+                'plural'     => [],
+                'contextual_plural' => [],
+                'nplurals'   => 2,
+                'plural_rule'=> 'n != 1',
             ];
         }
 
@@ -112,30 +181,42 @@ class Translations {
             return [
                 'default'    => [],
                 'contextual' => [],
+                'plural'     => [],
+                'contextual_plural' => [],
+                'nplurals'   => 2,
+                'plural_rule'=> 'n != 1',
             ];
         }
 
         $entries = [
             'default'    => [],
             'contextual' => [],
+            'plural'     => [],
+            'contextual_plural' => [],
+            'nplurals'   => 2,
+            'plural_rule'=> 'n != 1',
         ];
-        $msgid   = null;
-        $msgstr  = '';
-        $state   = null;
-        $context = null;
+        $msgid         = null;
+        $msgid_plural  = null;
+        $msgstr        = '';
+        $msgstr_plural = [];
+        $state         = null;
+        $context       = null;
 
         while ( false !== ( $line = fgets( $handle ) ) ) {
             $line = rtrim( $line, "\r\n" );
 
             if ( '' === $line ) {
                 if ( null !== $msgid ) {
-                    self::store_entry( $entries, $msgid, $msgstr, $context );
+                    self::store_entry( $entries, $msgid, $msgstr, $context, $msgid_plural, $msgstr_plural );
                 }
 
-                $msgid   = null;
-                $msgstr  = '';
-                $state   = null;
-                $context = null;
+                $msgid         = null;
+                $msgid_plural  = null;
+                $msgstr        = '';
+                $msgstr_plural = [];
+                $state         = null;
+                $context       = null;
                 continue;
             }
 
@@ -152,13 +233,28 @@ class Translations {
             if ( 0 === strpos( $line, 'msgid ' ) ) {
                 $msgid  = self::parse_po_string( substr( $line, 6 ) );
                 $msgstr = '';
+                $msgid_plural  = null;
+                $msgstr_plural = [];
                 $state  = 'msgid';
+                continue;
+            }
+
+            if ( 0 === strpos( $line, 'msgid_plural ' ) ) {
+                $msgid_plural = self::parse_po_string( substr( $line, 13 ) );
+                $state        = 'msgid_plural';
                 continue;
             }
 
             if ( 0 === strpos( $line, 'msgstr ' ) ) {
                 $msgstr = self::parse_po_string( substr( $line, 7 ) );
                 $state  = 'msgstr';
+                continue;
+            }
+
+            if ( preg_match( '/^msgstr\[(\d+)\]\s+(.+)$/', $line, $matches ) ) {
+                $index               = (int) $matches[1];
+                $msgstr_plural[ $index ] = self::parse_po_string( $matches[2] );
+                $state               = 'msgstr[' . $index . ']';
                 continue;
             }
 
@@ -169,6 +265,9 @@ class Translations {
                     $msgid .= self::parse_po_string( $line );
                 } elseif ( 'msgstr' === $state ) {
                     $msgstr .= self::parse_po_string( $line );
+                } elseif ( 0 === strpos( $state, 'msgstr[' ) ) {
+                    $index = (int) filter_var( $state, FILTER_SANITIZE_NUMBER_INT );
+                    $msgstr_plural[ $index ] = ( $msgstr_plural[ $index ] ?? '' ) . self::parse_po_string( $line );
                 }
             }
         }
@@ -176,7 +275,16 @@ class Translations {
         fclose( $handle );
 
         if ( null !== $msgid ) {
-            self::store_entry( $entries, $msgid, $msgstr, $context );
+            self::store_entry( $entries, $msgid, $msgstr, $context, $msgid_plural, $msgstr_plural );
+        }
+
+        // Normalise contextual plural entries into the expected structure.
+        if ( isset( $entries['contextual_plural'] ) ) {
+            foreach ( $entries['contextual_plural'] as $ctx => $values ) {
+                if ( ! is_array( $values ) ) {
+                    unset( $entries['contextual_plural'][ $ctx ] );
+                }
+            }
         }
 
         return $entries;
@@ -185,15 +293,38 @@ class Translations {
     /**
      * Store a parsed PO entry into the catalogue buckets.
      *
-     * @param array{default: array<string,string>, contextual: array<string,array<string,string>>} $entries Entries catalogue.
+     * @param array{
+     *     default: array<string,string>,
+     *     contextual: array<string,array<string,string>>,
+     *     plural: array<string,array<int,string>>,
+     *     contextual_plural: array<string,array<string,array<int,string>>>,
+     *     nplurals: int,
+     *     plural_rule: string,
+     * } $entries Entries catalogue.
      */
-    private static function store_entry( array &$entries, ?string $msgid, string $msgstr, ?string $context ): void {
+    private static function store_entry( array &$entries, ?string $msgid, string $msgstr, ?string $context, ?string $msgid_plural, array $msgstr_plural ): void {
         if ( null === $msgid ) {
             return;
         }
 
         if ( '' === $msgid && ( null === $context || '' === $context ) ) {
-            // Header entry, skip.
+            self::parse_headers( $entries, $msgstr );
+            return;
+        }
+
+        if ( null !== $msgid_plural && ! empty( $msgstr_plural ) ) {
+            ksort( $msgstr_plural );
+
+            if ( null !== $context && '' !== $context ) {
+                if ( ! isset( $entries['contextual_plural'][ $context ] ) ) {
+                    $entries['contextual_plural'][ $context ] = [];
+                }
+
+                $entries['contextual_plural'][ $context ][ $msgid ] = $msgstr_plural;
+                return;
+            }
+
+            $entries['plural'][ $msgid ] = $msgstr_plural;
             return;
         }
 
@@ -220,5 +351,102 @@ class Translations {
         }
 
         return stripcslashes( $value );
+    }
+
+    /**
+     * Parse the header block for plural information.
+     */
+    private static function parse_headers( array &$entries, string $headers ): void {
+        foreach ( preg_split( '/\n/', $headers ) as $header ) {
+            if ( false === strpos( $header, ':' ) ) {
+                continue;
+            }
+
+            [ $key, $value ] = array_map( 'trim', explode( ':', $header, 2 ) );
+
+            if ( 'Plural-Forms' !== $key ) {
+                continue;
+            }
+
+            if ( preg_match( '/nplurals\s*=\s*(\d+)/', $value, $matches ) ) {
+                $entries['nplurals'] = max( 1, (int) $matches[1] );
+            }
+
+            if ( preg_match( '/plural\s*=\s*([^;]+)/', $value, $matches ) ) {
+                $entries['plural_rule'] = trim( $matches[1] );
+            }
+        }
+    }
+
+    /**
+     * Look up the correct plural form from the catalogue.
+     */
+    private static function lookup_plural( array $catalogue, string $msgid, int $number, ?string $context ): ?string {
+        if ( null !== $context && '' !== $context ) {
+            $forms = $catalogue['contextual_plural'][ $context ][ $msgid ] ?? null;
+        } else {
+            $forms = $catalogue['plural'][ $msgid ] ?? null;
+        }
+
+        if ( ! is_array( $forms ) ) {
+            return null;
+        }
+
+        $index = self::determine_plural_index( $catalogue, $number );
+
+        if ( isset( $forms[ $index ] ) && '' !== $forms[ $index ] ) {
+            return $forms[ $index ];
+        }
+
+        foreach ( $forms as $form ) {
+            if ( '' !== $form ) {
+                return $form;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine the plural index for a given quantity.
+     */
+    private static function determine_plural_index( array $catalogue, int $number ): int {
+        $nplurals = isset( $catalogue['nplurals'] ) ? max( 1, (int) $catalogue['nplurals'] ) : 2;
+        $rule     = $catalogue['plural_rule'] ?? 'n != 1';
+
+        $rule = trim( $rule );
+
+        if ( '' === $rule ) {
+            return min( $nplurals - 1, ( 1 === $number ) ? 0 : 1 );
+        }
+
+        // Allow only safe characters before evaluating.
+        if ( preg_match( '/[^n0-9\s\(\)\?\:\|\&\!\<\>\=\+\-\*\/\%]/', $rule ) ) {
+            return min( $nplurals - 1, ( 1 === $number ) ? 0 : 1 );
+        }
+
+        $n      = (int) $number;
+        $result = 0;
+
+        try {
+            /** @psalm-suppress UnresolvableInclude */
+            $result = eval( 'return (int) (' . str_replace( 'n', '$n', $rule ) . ');' );
+        } catch ( \Throwable $e ) {
+            $result = ( 1 === $number ) ? 0 : 1;
+        }
+
+        if ( ! is_int( $result ) ) {
+            $result = (int) $result;
+        }
+
+        if ( $result < 0 ) {
+            $result = 0;
+        }
+
+        if ( $result >= $nplurals ) {
+            $result = $nplurals - 1;
+        }
+
+        return $result;
     }
 }

--- a/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
@@ -16,6 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: xgettext & polib\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: igs-ecommerce-customizations/includes/Admin/class-product-meta.php:53
 msgid "Aggiungi"
@@ -349,10 +350,12 @@ msgstr "Paese non specificato"
 msgid "Pagamento a rate disponibile"
 msgstr "Pagamento a rate disponibile"
 
-#: igs-ecommerce-customizations/includes/Frontend/class-product-display.php:126
+#: igs-ecommerce-customizations/includes/Frontend/class-product-display.php:127
 #: igs-ecommerce-customizations/includes/Frontend/class-loop-display.php:76
-msgid "giorni"
-msgstr "giorni"
+msgid "giorno"
+msgid_plural "giorni"
+msgstr[0] "giorno"
+msgstr[1] "giorni"
 
 #: igs-ecommerce-customizations/includes/Frontend/class-product-display.php:130
 msgid "Ingressi ai siti e giardini"

--- a/igs-ecommerce-customizations/languages/igs-ecommerce.pot
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce.pot
@@ -16,6 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: xgettext & polib\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: igs-ecommerce-customizations/includes/Admin/class-product-meta.php:53
 msgid "Aggiungi"
@@ -346,10 +347,12 @@ msgstr ""
 msgid "Pagamento a rate disponibile"
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Frontend/class-product-display.php:126
+#: igs-ecommerce-customizations/includes/Frontend/class-product-display.php:127
 #: igs-ecommerce-customizations/includes/Frontend/class-loop-display.php:76
-msgid "giorni"
-msgstr ""
+msgid "giorno"
+msgid_plural "giorni"
+msgstr[0] ""
+msgstr[1] ""
 
 #: igs-ecommerce-customizations/includes/Frontend/class-product-display.php:130
 msgid "Ingressi ai siti e giardini"


### PR DESCRIPTION
## Summary
- add plural-aware parsing and selection to the runtime translation loader and register ngettext filters
- switch tour duration displays to use `_n()` so singular values render correctly
- update the Italian PO catalogue and POT template with plural forms metadata and entries

## Testing
- php -l includes/class-translations.php
- php -l includes/Frontend/class-loop-display.php
- php -l includes/Frontend/class-product-display.php

------
https://chatgpt.com/codex/tasks/task_e_68d436bc4358832f92f2bf3d6da4177b