### PR TITLE
Harden tour map coordinates and encoding

### DIFF
--- a/igs-ecommerce-customizations/includes/Frontend/class-shortcodes.php
+++ b/igs-ecommerce-customizations/includes/Frontend/class-shortcodes.php
@@ -134,11 +134,11 @@ class Shortcodes {
 
         foreach ( $stops as $stop ) {
             $name = isset( $stop['nome'] ) ? sanitize_text_field( $stop['nome'] ) : '';
-            $lat  = isset( $stop['lat'] ) ? sanitize_text_field( $stop['lat'] ) : '';
-            $lon  = isset( $stop['lon'] ) ? sanitize_text_field( $stop['lon'] ) : '';
+            $lat  = isset( $stop['lat'] ) ? Helpers\normalize_latitude( $stop['lat'] ) : null;
+            $lon  = isset( $stop['lon'] ) ? Helpers\normalize_longitude( $stop['lon'] ) : null;
             $desc = isset( $stop['descrizione'] ) ? sanitize_textarea_field( $stop['descrizione'] ) : '';
 
-            if ( '' === $lat || '' === $lon ) {
+            if ( null === $lat || null === $lon ) {
                 continue;
             }
 
@@ -154,8 +154,9 @@ class Shortcodes {
             return '';
         }
 
-        $map_id  = 'igs-tour-map-' . $post_id . '-' . wp_rand( 1000, 9999 );
-        $country = get_post_meta( $post_id, '_mappa_paese', true );
+        $map_id      = 'igs-tour-map-' . $post_id . '-' . wp_rand( 1000, 9999 );
+        $country_raw = get_post_meta( $post_id, '_mappa_paese', true );
+        $country     = is_string( $country_raw ) ? sanitize_text_field( $country_raw ) : '';
 
         wp_enqueue_style( 'igs-leaflet' );
         wp_enqueue_style( 'igs-tour-map' );
@@ -175,8 +176,14 @@ class Shortcodes {
             'country' => $country,
         ];
 
+        $encoded = wp_json_encode( $data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+
+        if ( false === $encoded ) {
+            return '';
+        }
+
         return '<div class="igs-tour-map-wrapper">'
-            . '<div id="' . esc_attr( $map_id ) . '" class="igs-tour-map" data-map="' . esc_attr( wp_json_encode( $data ) ) . '"></div>'
+            . '<div id="' . esc_attr( $map_id ) . '" class="igs-tour-map" data-map="' . esc_attr( $encoded ) . '"></div>'
             . '<noscript>' . esc_html__( 'Abilita JavaScript per visualizzare la mappa del tour.', 'igs-ecommerce' ) . '</noscript>'
             . '</div>';
     }

--- a/igs-ecommerce-customizations/includes/helpers.php
+++ b/igs-ecommerce-customizations/includes/helpers.php
@@ -136,3 +136,50 @@ function calculate_duration( string $start, string $end ): ?int {
 
     return $start_date->diff( $end_date )->days + 1;
 }
+
+/**
+ * Normalise a latitude string into a safe decimal representation.
+ */
+function normalize_latitude( $value ): ?string {
+    return normalize_coordinate_value( $value, -90.0, 90.0 );
+}
+
+/**
+ * Normalise a longitude string into a safe decimal representation.
+ */
+function normalize_longitude( $value ): ?string {
+    return normalize_coordinate_value( $value, -180.0, 180.0 );
+}
+
+/**
+ * Internal helper that validates and formats coordinate values.
+ *
+ * @param mixed $value Raw coordinate value.
+ */
+function normalize_coordinate_value( $value, float $min, float $max ): ?string {
+    if ( ! is_scalar( $value ) ) {
+        return null;
+    }
+
+    $normalized = trim( (string) $value );
+
+    if ( '' === $normalized ) {
+        return null;
+    }
+
+    $normalized = str_replace( ',', '.', $normalized );
+
+    if ( ! is_numeric( $normalized ) ) {
+        return null;
+    }
+
+    $float = (float) $normalized;
+
+    if ( $float < $min || $float > $max ) {
+        return null;
+    }
+
+    $formatted = sprintf( '%.6F', $float );
+
+    return rtrim( rtrim( $formatted, '0' ), '.' );
+}


### PR DESCRIPTION
## Summary
- add helper utilities to normalise latitude and longitude values before storing or rendering them
- sanitise itinerary stops saved in the backend and validate coordinates returned by the geocoding endpoint
- ensure the front-end map shortcode only outputs vetted coordinates and safely encoded JSON payloads

## Testing
- php -l igs-ecommerce-customizations/includes/helpers.php
- php -l igs-ecommerce-customizations/includes/Admin/class-map-meta-box.php
- php -l igs-ecommerce-customizations/includes/Frontend/class-shortcodes.php

------
https://chatgpt.com/codex/tasks/task_e_68d43bef19ec832f99f881577c701e96