### PR TITLE
Add uninstall cleanup for plugin data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Questo repository contiene il plugin WordPress **IGS Ecommerce Customizations**,
 2. Carica l’archivio dal pannello **Plugin → Aggiungi nuovo** di WordPress e attivalo.
 3. Dopo l’attivazione il plugin non richiede configurazioni aggiuntive: le funzionalità vengono applicate automaticamente ai prodotti tour.
 
+## Disinstallazione
+
+- La rimozione del plugin da **Plugin → Plugin installati** elimina automaticamente le opzioni di configurazione (`gw_string_replacements_global`) e svuota i transient utilizzati dalla funzione di geocoding, così da non lasciare dati orfani nel database.
+
 ## Dipendenze incluse
 
 - **Leaflet 1.9.4** (JS/CSS) viene caricato da `https://unpkg.com/` tramite gli hook `igs_leaflet_style_url` e `igs_leaflet_script_url`, così da evitare asset binari nel repository mantenendo la possibilità di sostituire l’origine.

--- a/igs-ecommerce-customizations/uninstall.php
+++ b/igs-ecommerce-customizations/uninstall.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin uninstall routine.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+// Remove plugin specific options.
+delete_option( 'gw_string_replacements_global' );
+delete_site_option( 'gw_string_replacements_global' );
+
+// Clear transients used by the geocoding helper.
+delete_transient( 'igs_geocode_rate_limit' );
+delete_site_transient( 'igs_geocode_rate_limit' );
+
+global $wpdb;
+
+if ( isset( $wpdb->options ) ) {
+    $like_base    = $wpdb->esc_like( '_transient_igs_geocode_' ) . '%';
+    $like_timeout = $wpdb->esc_like( '_transient_timeout_igs_geocode_' ) . '%';
+
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $like_base ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $like_timeout ) );
+}
+
+if ( is_multisite() && isset( $wpdb->sitemeta ) ) {
+    $like_base    = $wpdb->esc_like( '_site_transient_igs_geocode_' ) . '%';
+    $like_timeout = $wpdb->esc_like( '_site_transient_timeout_igs_geocode_' ) . '%';
+
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $like_base ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $like_timeout ) );
+}


### PR DESCRIPTION
## Summary
- add an uninstall routine that clears the global string replacements option and cached geocoding transients
- document the uninstall behaviour in the README so operators know what data is removed

## Testing
- php -l igs-ecommerce-customizations/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d43d7830e0832fb7c1d1bbea0ffd0e