### PR TITLE
Hardening: rate limit and validate tour info AJAX

### DIFF
--- a/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
@@ -423,35 +423,39 @@ msgstr "Impossibile aggiungere il prodotto al carrello."
 msgid "Per favore, compila correttamente nome ed email."
 msgstr "Per favore, compila correttamente nome ed email."
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:108
-msgid "Tour non specificato"
-msgstr "Tour non specificato"
-
 #: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:111
+msgid "Tour non disponibile."
+msgstr "Tour non disponibile."
+
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:114
 #, php-format
 msgid "Richiesta informazioni per il tour: %s"
 msgstr "Richiesta informazioni per il tour: %s"
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:113
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:116
 msgid "Nuova Richiesta Informazioni"
 msgstr "Nuova Richiesta Informazioni"
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:114
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:117
 #, php-format
 msgid "Hai ricevuto una nuova richiesta per il tour: %s"
 msgstr "Hai ricevuto una nuova richiesta per il tour: %s"
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:121
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:124
 msgid "Messaggio"
 msgstr "Messaggio"
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:134
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:137
 msgid "Email inviata con successo."
 msgstr "Email inviata con successo."
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:137
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:140
 msgid "Impossibile inviare l'email. Riprova più tardi."
 msgstr "Impossibile inviare l'email. Riprova più tardi."
+
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:164
+msgid "Hai raggiunto il limite di richieste. Riprova più tardi."
+msgstr "Hai raggiunto il limite di richieste. Riprova più tardi."
 
 #: igs-ecommerce-customizations/includes/Frontend/class-shortcodes.php:33
 msgid "Cultura"

--- a/igs-ecommerce-customizations/languages/igs-ecommerce.pot
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce.pot
@@ -420,34 +420,38 @@ msgstr ""
 msgid "Per favore, compila correttamente nome ed email."
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:108
-msgid "Tour non specificato"
-msgstr ""
-
 #: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:111
-#, php-format
-msgid "Richiesta informazioni per il tour: %s"
-msgstr ""
-
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:113
-msgid "Nuova Richiesta Informazioni"
+msgid "Tour non disponibile."
 msgstr ""
 
 #: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:114
 #, php-format
+msgid "Richiesta informazioni per il tour: %s"
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:116
+msgid "Nuova Richiesta Informazioni"
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:117
+#, php-format
 msgid "Hai ricevuto una nuova richiesta per il tour: %s"
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:121
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:124
 msgid "Messaggio"
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:134
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:137
 msgid "Email inviata con successo."
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:137
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:140
 msgid "Impossibile inviare l'email. Riprova più tardi."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php:164
+msgid "Hai raggiunto il limite di richieste. Riprova più tardi."
 msgstr ""
 
 #: igs-ecommerce-customizations/includes/Frontend/class-shortcodes.php:33


### PR DESCRIPTION
## Summary
- validate information request submissions to ensure they target existing tour products
- add configurable rate limiting and flexible recipient handling to the tour info AJAX endpoint
- update translation templates to include the new user-facing messaging

## Testing
- php -l igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php

------
https://chatgpt.com/codex/tasks/task_e_68d43eba85cc832fabcace7da82a5e5c