### PR TITLE
Cache parsed translations for production

### DIFF
--- a/igs-ecommerce-customizations/uninstall.php
+++ b/igs-ecommerce-customizations/uninstall.php
@@ -32,6 +32,13 @@ if ( isset( $wpdb->options ) ) {
 
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $info_like_base ) );
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $info_like_timeout ) );
+
+    // Remove cached translation catalogues.
+    $translations_like_base    = $wpdb->esc_like( '_transient_igs_translation_' ) . '%';
+    $translations_like_timeout = $wpdb->esc_like( '_transient_timeout_igs_translation_' ) . '%';
+
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $translations_like_base ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $translations_like_timeout ) );
 }
 
 if ( is_multisite() && isset( $wpdb->sitemeta ) ) {
@@ -47,4 +54,11 @@ if ( is_multisite() && isset( $wpdb->sitemeta ) ) {
 
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $info_like_base ) );
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $info_like_timeout ) );
+
+    // Remove cached translation catalogues from the network table as well.
+    $translations_like_base    = $wpdb->esc_like( '_site_transient_igs_translation_' ) . '%';
+    $translations_like_timeout = $wpdb->esc_like( '_site_transient_timeout_igs_translation_' ) . '%';
+
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $translations_like_base ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $translations_like_timeout ) );
 }


### PR DESCRIPTION
## Summary
- cache parsed PO catalogues using object cache/transients to avoid reparsing on every request
- centralise the empty translation catalogue structure and reuse it when files are missing or unreadable
- purge cached translation transients during uninstall to keep the database clean

## Testing
- find igs-ecommerce-customizations -name "*.php" -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d4418f94e8832fb1fefde8a1c41417