### PR TITLE
Allow configuring tour map tile provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Questo repository contiene il plugin WordPress **IGS Ecommerce Customizations**,
 - Per modificare i comportamenti del modal di prenotazione puoi agganciare i filtri:
   - `igs_booking_should_empty_cart` per forzare lo svuotamento del carrello prima dell’aggiunta.
   - `igs_portfolio_partner_logo` per impostare un logo partner personalizzato nelle schede portfolio.
+  - `igs_tour_map_tile_layer` per definire URL, attributi e opzioni del tile provider utilizzato dalla mappa Leaflet.
 - Se aggiungi o aggiorni stringhe localizzate esegui `xgettext` o un equivalente (`wp i18n make-pot`) per rigenerare `languages/igs-ecommerce.pot`, quindi aggiorna `languages/igs-ecommerce-it_IT.po`. Il plugin carica direttamente i file `.po`, ma puoi comunque compilare `.mo` se distribuisci il pacchetto tramite altri canali.
 
 Per contributi o segnalazioni apri una issue o una pull request descrivendo in modo chiaro le modifiche proposte.

--- a/igs-ecommerce-customizations/assets/js/map.js
+++ b/igs-ecommerce-customizations/assets/js/map.js
@@ -5,10 +5,24 @@
             return;
         }
 
+        var config = window.igsTourMapConfig || {};
+        var tileUrl = typeof config.tileUrl === 'string' && config.tileUrl ? config.tileUrl : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+        var tileOptions = {};
+
+        if (config.tileOptions && typeof config.tileOptions === 'object') {
+            Object.keys(config.tileOptions).forEach(function (key) {
+                tileOptions[key] = config.tileOptions[key];
+            });
+        }
+
+        if (typeof config.tileAttribution === 'string' && config.tileAttribution) {
+            tileOptions.attribution = config.tileAttribution;
+        } else if (typeof tileOptions.attribution === 'undefined') {
+            tileOptions.attribution = '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors';
+        }
+
         var map = L.map(element, { scrollWheelZoom: false, tap: true });
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
-        }).addTo(map);
+        L.tileLayer(tileUrl, tileOptions).addTo(map);
 
         var points = [];
 


### PR DESCRIPTION
## Summary
- add a sanitized `igs_tour_map_tile_layer` filter to configure the Leaflet tile provider and expose it to the front-end
- update the map script to honour the localized tile configuration at runtime
- document the new customization hook in the README

## Testing
- php -l igs-ecommerce-customizations/includes/Frontend/class-shortcodes.php

------
https://chatgpt.com/codex/tasks/task_e_68d446fbb40c832f981b6109ce9a5856