### PR TITLE
Harden dependency checks for production readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Questo repository contiene il plugin WordPress **IGS Ecommerce Customizations**,
 2. Carica l’archivio dal pannello **Plugin → Aggiungi nuovo** di WordPress e attivalo.
 3. Dopo l’attivazione il plugin non richiede configurazioni aggiuntive: le funzionalità vengono applicate automaticamente ai prodotti tour.
 
+## Requisiti minimi
+
+- PHP **7.4**
+- WordPress **6.0**
+- WooCommerce **7.0**
+
 ## Disinstallazione
 
 - La rimozione del plugin da **Plugin → Plugin installati** elimina automaticamente le opzioni di configurazione (`gw_string_replacements_global`) e svuota i transient utilizzati dalla funzione di geocoding, così da non lasciare dati orfani nel database.

--- a/igs-ecommerce-customizations/igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/igs-ecommerce-customizations.php
@@ -3,7 +3,7 @@
  * Plugin Name:       IGS Ecommerce Customizations
  * Plugin URI:        https://example.com/
  * Description:       Raccolta di personalizzazioni per Il Giardino Segreto su WooCommerce.
- * Version:           1.2.1
+ * Version:           1.3.0
  * Author:            Il Giardino Segreto
  * Author URI:        https://example.com/
  * Text Domain:       igs-ecommerce
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'IGS_ECOMMERCE_VERSION', '1.2.1' );
+define( 'IGS_ECOMMERCE_VERSION', '1.3.0' );
 define( 'IGS_ECOMMERCE_FILE', __FILE__ );
 define( 'IGS_ECOMMERCE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IGS_ECOMMERCE_URL', plugin_dir_url( __FILE__ ) );

--- a/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
@@ -5,10 +5,10 @@
 
 msgid ""
 msgstr ""
-"Project-Id-Version: IGS Ecommerce Customizations 1.2.0\n"
+"Project-Id-Version: IGS Ecommerce Customizations 1.3.0\n"
 "Report-Msgid-Bugs-To: https://ilgiardinosegreto.it/\n"
-"POT-Creation-Date: 2025-09-24 11:10+0000\n"
-"PO-Revision-Date: 2025-09-24 11:10+0000\n"
+"POT-Creation-Date: 2025-10-09 12:00+0000\n"
+"PO-Revision-Date: 2025-10-09 12:00+0000\n"
 "Last-Translator: Il Giardino Segreto <translations@example.com>\n"
 "Language-Team: Il Giardino Segreto <translations@example.com>\n"
 "Language: it\n"
@@ -496,3 +496,34 @@ msgstr "Destinazioni fuori dai sentieri battuti"
 #: igs-ecommerce-customizations/includes/Frontend/class-shop-page.php:73
 msgid "Ritorna al sito web"
 msgstr "Ritorna al sito web"
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:93
+msgid "IGS Ecommerce Customizations non può avviarsi perché alcuni requisiti non sono soddisfatti."
+msgstr "IGS Ecommerce Customizations non può avviarsi perché alcuni requisiti non sono soddisfatti."
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:95
+msgid "Per favore, risolvi i seguenti problemi e riprova ad attivare il plugin."
+msgstr "Per favore, risolvi i seguenti problemi e riprova ad attivare il plugin."
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:115
+#, php-format
+msgid "IGS Ecommerce Customizations richiede PHP %1$s o superiore. Versione corrente: %2$s."
+msgstr "IGS Ecommerce Customizations richiede PHP %1$s o superiore. Versione corrente: %2$s."
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:126
+#, php-format
+msgid "IGS Ecommerce Customizations richiede WordPress %1$s o superiore. Versione corrente: %2$s."
+msgstr "IGS Ecommerce Customizations richiede WordPress %1$s o superiore. Versione corrente: %2$s."
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:133
+msgid "WooCommerce non è installato o attivo."
+msgstr "WooCommerce non è installato o attivo."
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:138
+msgid "Impossibile determinare la versione di WooCommerce installata."
+msgstr "Impossibile determinare la versione di WooCommerce installata."
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:142
+#, php-format
+msgid "IGS Ecommerce Customizations richiede WooCommerce %1$s o superiore. Versione corrente: %2$s."
+msgstr "IGS Ecommerce Customizations richiede WooCommerce %1$s o superiore. Versione corrente: %2$s."

--- a/igs-ecommerce-customizations/languages/igs-ecommerce.pot
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce.pot
@@ -5,10 +5,10 @@
 
 msgid ""
 msgstr ""
-"Project-Id-Version: IGS Ecommerce Customizations 1.2.0\n"
+"Project-Id-Version: IGS Ecommerce Customizations 1.3.0\n"
 "Report-Msgid-Bugs-To: https://ilgiardinosegreto.it/\n"
-"POT-Creation-Date: 2025-09-24 11:10+0000\n"
-"PO-Revision-Date: 2025-09-24 11:10+0000\n"
+"POT-Creation-Date: 2025-10-09 12:00+0000\n"
+"PO-Revision-Date: 2025-10-09 12:00+0000\n"
 "Last-Translator: Il Giardino Segreto <translations@example.com>\n"
 "Language-Team: Il Giardino Segreto <translations@example.com>\n"
 "Language: \n"
@@ -492,4 +492,35 @@ msgstr ""
 
 #: igs-ecommerce-customizations/includes/Frontend/class-shop-page.php:73
 msgid "Ritorna al sito web"
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:93
+msgid "IGS Ecommerce Customizations non può avviarsi perché alcuni requisiti non sono soddisfatti."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:95
+msgid "Per favore, risolvi i seguenti problemi e riprova ad attivare il plugin."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:115
+#, php-format
+msgid "IGS Ecommerce Customizations richiede PHP %1$s o superiore. Versione corrente: %2$s."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:126
+#, php-format
+msgid "IGS Ecommerce Customizations richiede WordPress %1$s o superiore. Versione corrente: %2$s."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:133
+msgid "WooCommerce non è installato o attivo."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:138
+msgid "Impossibile determinare la versione di WooCommerce installata."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-dependencies.php:142
+#, php-format
+msgid "IGS Ecommerce Customizations richiede WooCommerce %1$s o superiore. Versione corrente: %2$s."
 msgstr ""


### PR DESCRIPTION
## Summary
- validate PHP, WordPress, and WooCommerce requirements before bootstrapping the plugin and improve the admin notice output
- bump the plugin version and document the minimum supported stack in the README
- refresh the translation template and Italian catalogue with the new dependency messages

## Testing
- php -l igs-ecommerce-customizations/igs-ecommerce-customizations.php
- php -l igs-ecommerce-customizations/includes/class-dependencies.php

------
https://chatgpt.com/codex/tasks/task_e_68d44ae75a14832faa06d920db44e1b4