### PR TITLE
Add activation dependency validation

### DIFF
--- a/igs-ecommerce-customizations/igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/igs-ecommerce-customizations.php
@@ -21,6 +21,8 @@ define( 'IGS_ECOMMERCE_URL', plugin_dir_url( __FILE__ ) );
 
 require_once IGS_ECOMMERCE_PATH . 'includes/class-dependencies.php';
 
+register_activation_hook( IGS_ECOMMERCE_FILE, [ 'IGS\\Ecommerce\\Dependencies', 'on_activation' ] );
+
 if ( ! IGS\Ecommerce\Dependencies::bootstrap() ) {
     return;
 }


### PR DESCRIPTION
## Summary
- add an activation hook that stops the plugin from activating when requirements are missing
- refactor dependency notices to reuse a shared error list renderer

## Testing
- php -l igs-ecommerce-customizations/igs-ecommerce-customizations.php
- php -l igs-ecommerce-customizations/includes/class-dependencies.php

------
https://chatgpt.com/codex/tasks/task_e_68d454c0254c832fadc5d399bfb5e84f