### PR TITLE
Add caching for tour product detection

### DIFF
--- a/igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php
@@ -56,6 +56,7 @@ final class Plugin {
         require_once IGS_ECOMMERCE_PATH . 'includes/helpers.php';
 
         Translations::init();
+        Helpers\register_tour_product_cache_invalidation();
 
         // Admin modules.
         require_once IGS_ECOMMERCE_PATH . 'includes/Admin/class-product-meta.php';


### PR DESCRIPTION
## Summary
- cache tour product detection results using both in-memory and object caches to reduce repeated lookups
- register cache invalidation hooks to keep cached flags in sync with metadata and taxonomy changes
- bootstrap the cache invalidation hooks during plugin initialization

## Testing
- php -l igs-ecommerce-customizations/includes/helpers.php
- php -l igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php

------
https://chatgpt.com/codex/tasks/task_e_68d456722228832f9b173f89ca140f03