### PR TITLE
Improve translation cache busting on updates

### DIFF
--- a/igs-ecommerce-customizations/includes/class-translations.php
+++ b/igs-ecommerce-customizations/includes/class-translations.php
@@ -354,6 +354,10 @@ class Translations {
     private static function build_cache_key( string $locale, string $file ): string {
         $parts = [ $locale ];
 
+        if ( defined( 'IGS_ECOMMERCE_VERSION' ) ) {
+            $parts[] = IGS_ECOMMERCE_VERSION;
+        }
+
         if ( is_readable( $file ) ) {
             $mtime = @filemtime( $file );
             $size  = @filesize( $file );


### PR DESCRIPTION
## Summary
- include the plugin version in the translation cache key so new releases invalidate stale cached catalogues

## Testing
- php -l includes/class-translations.php

------
https://chatgpt.com/codex/tasks/task_e_68d45d073804832f9a89ff4bb73817c6