### PR TITLE
Improve geocode rate limiting

### DIFF
--- a/igs-ecommerce-customizations/uninstall.php
+++ b/igs-ecommerce-customizations/uninstall.php
@@ -26,6 +26,12 @@ if ( isset( $wpdb->options ) ) {
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $like_base ) );
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $like_timeout ) );
 
+    $rl_like_base    = $wpdb->esc_like( '_transient_igs_geocode_rl_' ) . '%';
+    $rl_like_timeout = $wpdb->esc_like( '_transient_timeout_igs_geocode_rl_' ) . '%';
+
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $rl_like_base ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $rl_like_timeout ) );
+
     // Remove stored booking/info rate limit windows.
     $info_like_base    = $wpdb->esc_like( '_transient_igs_info_rl_' ) . '%';
     $info_like_timeout = $wpdb->esc_like( '_transient_timeout_igs_info_rl_' ) . '%';
@@ -47,6 +53,12 @@ if ( is_multisite() && isset( $wpdb->sitemeta ) ) {
 
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $like_base ) );
     $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $like_timeout ) );
+
+    $rl_like_base    = $wpdb->esc_like( '_site_transient_igs_geocode_rl_' ) . '%';
+    $rl_like_timeout = $wpdb->esc_like( '_site_transient_timeout_igs_geocode_rl_' ) . '%';
+
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $rl_like_base ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s", $rl_like_timeout ) );
 
     // Remove stored booking/info rate limit windows on the network table too.
     $info_like_base    = $wpdb->esc_like( '_site_transient_igs_info_rl_' ) . '%';


### PR DESCRIPTION
## Summary
- scope the map geocoding rate limiter to the current user or client IP to avoid cross-user lockouts and send a Retry-After hint when throttled
- ensure all error paths clear the scoped limiter before returning
- remove the new rate limiter transients during uninstall to keep the database tidy

## Testing
- php -l igs-ecommerce-customizations/includes/Admin/class-map-meta-box.php
- php -l igs-ecommerce-customizations/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d45dfc7ca0832f87e6e40d33ff7f01