### PR TITLE
Validate portfolio dates before saving

### DIFF
--- a/igs-ecommerce-customizations/includes/Admin/class-portfolio-meta.php
+++ b/igs-ecommerce-customizations/includes/Admin/class-portfolio-meta.php
@@ -7,6 +7,8 @@
 
 namespace IGS\Ecommerce\Admin;
 
+use IGS\Ecommerce\Helpers;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -41,8 +43,8 @@ class Portfolio_Meta {
      * Render the controls.
      */
     public static function render( \WP_Post $post ): void {
-        $departure = get_post_meta( $post->ID, '_data_partenza', true );
-        $return    = get_post_meta( $post->ID, '_data_arrivo', true );
+        $departure = Helpers\normalize_html5_date( get_post_meta( $post->ID, '_data_partenza', true ) ) ?? '';
+        $return    = Helpers\normalize_html5_date( get_post_meta( $post->ID, '_data_arrivo', true ) ) ?? '';
 
         wp_nonce_field( 'igs_save_portfolio_dates', 'igs_portfolio_dates_nonce' );
 
@@ -70,10 +72,14 @@ class Portfolio_Meta {
         }
 
         foreach ( [ 'data_partenza', 'data_arrivo' ] as $field ) {
-            if ( isset( $_POST[ $field ] ) && '' !== $_POST[ $field ] ) {
-                update_post_meta( $post_id, '_' . $field, sanitize_text_field( wp_unslash( $_POST[ $field ] ) ) );
-            } else {
-                delete_post_meta( $post_id, '_' . $field );
+            if ( isset( $_POST[ $field ] ) ) {
+                $value = Helpers\normalize_html5_date( wp_unslash( $_POST[ $field ] ) );
+
+                if ( null !== $value ) {
+                    update_post_meta( $post_id, '_' . $field, $value );
+                } else {
+                    delete_post_meta( $post_id, '_' . $field );
+                }
             }
         }
     }

--- a/igs-ecommerce-customizations/includes/helpers.php
+++ b/igs-ecommerce-customizations/includes/helpers.php
@@ -242,6 +242,47 @@ function normalize_longitude( $value ): ?string {
 }
 
 /**
+ * Normalise an HTML5 date (YYYY-MM-DD) string.
+ */
+function normalize_html5_date( $value ): ?string {
+    if ( ! is_scalar( $value ) ) {
+        return null;
+    }
+
+    $normalized = trim( (string) $value );
+
+    if ( '' === $normalized ) {
+        return null;
+    }
+
+    $timezone = null;
+
+    if ( function_exists( 'wp_timezone' ) ) {
+        $wp_timezone = wp_timezone();
+
+        if ( $wp_timezone instanceof \DateTimeZone ) {
+            $timezone = $wp_timezone;
+        }
+    }
+
+    $date = $timezone instanceof \DateTimeZone
+        ? \DateTime::createFromFormat( '!Y-m-d', $normalized, $timezone )
+        : \DateTime::createFromFormat( '!Y-m-d', $normalized );
+
+    if ( ! $date instanceof \DateTime ) {
+        return null;
+    }
+
+    $errors = \DateTime::getLastErrors();
+
+    if ( is_array( $errors ) && ( (int) ( $errors['warning_count'] ?? 0 ) > 0 || (int) ( $errors['error_count'] ?? 0 ) > 0 ) ) {
+        return null;
+    }
+
+    return $date->format( 'Y-m-d' );
+}
+
+/**
  * Internal helper that validates and formats coordinate values.
  *
  * @param mixed $value Raw coordinate value.


### PR DESCRIPTION
## Summary
- add a helper that normalises HTML5 date strings before persisting them
- ensure portfolio meta fields use the new helper both when rendering and when saving

## Testing
- php -l includes/helpers.php
- php -l includes/Admin/class-portfolio-meta.php

------
https://chatgpt.com/codex/tasks/task_e_68d4f9d1c9b8832f9d73b117aa23fe68