### PR TITLE
Improve geocoding compliance and contact email handling

### DIFF
--- a/igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php
+++ b/igs-ecommerce-customizations/includes/Frontend/class-ajax-handlers.php
@@ -147,18 +147,8 @@ class Ajax_Handlers {
 
         self::enforce_info_rate_limit();
 
-        $tour_title = $product->get_title();
-        $admin_mail = get_option( 'admin_email' );
-
-        if ( ! is_string( $admin_mail ) || '' === $admin_mail ) {
-            $blog_admin = get_bloginfo( 'admin_email', 'display' );
-
-            if ( is_string( $blog_admin ) && '' !== $blog_admin ) {
-                $admin_mail = $blog_admin;
-            } else {
-                $admin_mail = '';
-            }
-        }
+        $tour_title  = $product->get_title();
+        $admin_mail  = Helpers\get_admin_contact_email();
 
         $subject = sprintf( __( 'Richiesta informazioni per il tour: %s', 'igs-ecommerce' ), $tour_title );
 
@@ -182,7 +172,7 @@ class Ajax_Handlers {
 
         $headers   = [ 'Content-Type: text/html; charset=UTF-8' ];
         $from_name = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
-        $from_mail = sanitize_email( $admin_mail );
+        $from_mail = $admin_mail ? sanitize_email( $admin_mail ) : '';
 
         if ( $from_mail && is_email( $from_mail ) ) {
             $headers[] = 'From: ' . $from_name . ' <' . $from_mail . '>';

--- a/igs-ecommerce-customizations/includes/helpers.php
+++ b/igs-ecommerce-customizations/includes/helpers.php
@@ -32,6 +32,45 @@ function url( string $relative ): string {
 }
 
 /**
+ * Retrieve a sanitized contact email address for the site administrator.
+ */
+function get_admin_contact_email(): ?string {
+    $candidates = [];
+
+    $option_email = get_option( 'admin_email' );
+
+    if ( is_string( $option_email ) && '' !== $option_email ) {
+        $candidates[] = $option_email;
+    }
+
+    $blog_email = get_bloginfo( 'admin_email', 'display' );
+
+    if ( is_string( $blog_email ) && '' !== $blog_email ) {
+        $candidates[] = $blog_email;
+    }
+
+    foreach ( $candidates as $candidate ) {
+        $sanitized = sanitize_email( $candidate );
+
+        if ( $sanitized && is_email( $sanitized ) ) {
+            /**
+             * Filter the contact email address used for external services.
+             *
+             * @param string|null $sanitized Email address, if available.
+             */
+            return apply_filters( 'igs_admin_contact_email', $sanitized );
+        }
+    }
+
+    /**
+     * Allow customization of the fallback value when no valid email is available.
+     *
+     * @param string|null $value Null by default when no email is found.
+     */
+    return apply_filters( 'igs_admin_contact_email', null );
+}
+
+/**
  * Determine whether the provided product should be handled as a tour.
  *
  * @param int|WC_Product|null $product Product instance or ID.


### PR DESCRIPTION
## Summary
- add a helper to expose a filtered, sanitised contact email for the site administrator
- reuse the helper in the public info-request AJAX handler to set headers consistently
- build geocoding requests with contact details, Accept-Language hints and a filterable request payload for better production compliance

## Testing
- php -l includes/helpers.php
- php -l includes/Frontend/class-ajax-handlers.php
- php -l includes/Admin/class-map-meta-box.php

------
https://chatgpt.com/codex/tasks/task_e_68d4fc5c339c832fb6c9bfa32b9669b1