### PR TITLE
Add WP-CLI cache maintenance command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,8 @@ Questo repository contiene il plugin WordPress **IGS Ecommerce Customizations**,
   - `igs_tour_map_tile_layer` per definire URL, attributi e opzioni del tile provider utilizzato dalla mappa Leaflet.
 - Se aggiungi o aggiorni stringhe localizzate esegui `xgettext` o un equivalente (`wp i18n make-pot`) per rigenerare `languages/igs-ecommerce.pot`, quindi aggiorna `languages/igs-ecommerce-it_IT.po`. Il plugin carica direttamente i file `.po`, ma puoi comunque compilare `.mo` se distribuisci il pacchetto tramite altri canali.
 
+## Utilità WP-CLI
+
+- Esegui `wp igs flush-caches` per svuotare le cache del plugin (tour, geocoding, rate limiting e traduzioni) dopo aver aggiornato i dati o in caso di ambienti con oggetti cache persistenti.
+
 Per contributi o segnalazioni apri una issue o una pull request descrivendo in modo chiaro le modifiche proposte.

--- a/igs-ecommerce-customizations/includes/class-cli-commands.php
+++ b/igs-ecommerce-customizations/includes/class-cli-commands.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * WP-CLI commands for maintenance tasks.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS\Ecommerce;
+
+use IGS\Ecommerce\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register WP-CLI commands that help operating the plugin in production.
+ */
+class CLI_Commands {
+    /**
+     * Register commands when WP-CLI is available.
+     */
+    public static function register(): void {
+        if ( ! class_exists( '\\WP_CLI' ) ) {
+            return;
+        }
+
+        \WP_CLI::add_command( 'igs flush-caches', [ __CLASS__, 'flush_caches' ] );
+    }
+
+    /**
+     * Flush plugin specific caches and transients.
+     *
+     * @param array<int,string> $args       Positional arguments (unused).
+     * @param array<string,string> $assoc_args Associative arguments (unused).
+     */
+    public static function flush_caches( array $args = [], array $assoc_args = [] ): void {
+        if ( ! class_exists( '\\WP_CLI' ) ) {
+            return;
+        }
+
+        $tour_count = self::flush_tour_cache();
+        \WP_CLI::log( sprintf( __( 'Cache dei tour ripulita per %d prodotti.', 'igs-ecommerce' ), $tour_count ) );
+
+        $geocode_count = self::flush_geocode_caches();
+        \WP_CLI::log( sprintf( __( 'Eliminati %d transient di geocoding.', 'igs-ecommerce' ), $geocode_count ) );
+
+        $info_count = self::flush_info_rate_limit_caches();
+        \WP_CLI::log( sprintf( __( 'Eliminati %d transient di rate limiting.', 'igs-ecommerce' ), $info_count ) );
+
+        $translation_count = self::flush_translation_caches();
+        \WP_CLI::log( sprintf( __( 'Ripuliti %d transient di traduzione.', 'igs-ecommerce' ), $translation_count ) );
+
+        \WP_CLI::success( __( 'Cache del plugin svuotate.', 'igs-ecommerce' ) );
+    }
+
+    /**
+     * Reset cached tour classification results.
+     */
+    private static function flush_tour_cache(): int {
+        global $igs_ecommerce_tour_cache;
+
+        if ( is_array( $igs_ecommerce_tour_cache ) ) {
+            $igs_ecommerce_tour_cache = [];
+        }
+
+        global $wpdb;
+
+        if ( ! isset( $wpdb->posts ) ) {
+            return 0;
+        }
+
+        $ids = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'product'" );
+
+        if ( empty( $ids ) ) {
+            return 0;
+        }
+
+        $ids    = array_map( 'intval', $ids );
+        $ids    = array_values( array_unique( $ids ) );
+        $count  = 0;
+
+        foreach ( $ids as $id ) {
+            wp_cache_delete( $id, Helpers\TOUR_PRODUCT_CACHE_GROUP );
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Remove cached geocoding responses and rate limits.
+     */
+    private static function flush_geocode_caches(): int {
+        $total = 0;
+
+        $total += self::flush_prefixed_transients( 'igs_geocode_' );
+        $total += self::flush_prefixed_transients( 'igs_geocode_rl_' );
+
+        return $total;
+    }
+
+    /**
+     * Clear booking/info rate limiting windows.
+     */
+    private static function flush_info_rate_limit_caches(): int {
+        return self::flush_prefixed_transients( 'igs_info_rl_' );
+    }
+
+    /**
+     * Flush cached translation catalogues.
+     */
+    private static function flush_translation_caches(): int {
+        $count = self::flush_prefixed_transients( 'igs_translation_', true );
+        Translations::flush_runtime_cache();
+
+        return $count;
+    }
+
+    /**
+     * Delete transients with the provided prefix across single and multisite tables.
+     *
+     * @param string $prefix               Transient prefix, without the `_transient_` part.
+     * @param bool   $clear_translation_oc Whether to clear the translation object cache group.
+     */
+    private static function flush_prefixed_transients( string $prefix, bool $clear_translation_oc = false ): int {
+        $count = self::flush_transients_in_table( $prefix, false, $clear_translation_oc );
+
+        if ( is_multisite() ) {
+            $count += self::flush_transients_in_table( $prefix, true, $clear_translation_oc );
+        }
+
+        return $count;
+    }
+
+    /**
+     * Delete transients from a specific storage table.
+     */
+    private static function flush_transients_in_table( string $prefix, bool $network, bool $clear_translation_oc ): int {
+        global $wpdb;
+
+        $table  = $network ? $wpdb->sitemeta : $wpdb->options;
+        $column = $network ? 'meta_key' : 'option_name';
+        $pattern = $network ? '_site_transient_' : '_transient_';
+
+        if ( empty( $table ) ) {
+            return 0;
+        }
+
+        $like = $wpdb->esc_like( $pattern . $prefix ) . '%';
+        $sql  = $wpdb->prepare( "SELECT {$column} FROM {$table} WHERE {$column} LIKE %s", $like );
+        $rows = $wpdb->get_col( $sql );
+
+        if ( empty( $rows ) ) {
+            return 0;
+        }
+
+        $deleted = 0;
+
+        foreach ( $rows as $option_name ) {
+            if ( 0 !== strpos( $option_name, $pattern ) ) {
+                continue;
+            }
+
+            $key = substr( $option_name, strlen( $pattern ) );
+
+            if ( $network ) {
+                delete_site_transient( $key );
+            } else {
+                delete_transient( $key );
+            }
+
+            if ( $clear_translation_oc ) {
+                wp_cache_delete( $key, Translations::get_cache_group() );
+            }
+
+            $deleted++;
+        }
+
+        return $deleted;
+    }
+}

--- a/igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php
@@ -89,5 +89,11 @@ final class Plugin {
         Frontend\Shortcodes::init();
         Frontend\Ajax_Handlers::init();
         Frontend\Portfolio_Display::init();
+
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            require_once IGS_ECOMMERCE_PATH . 'includes/class-cli-commands.php';
+
+            CLI_Commands::register();
+        }
     }
 }

--- a/igs-ecommerce-customizations/includes/class-translations.php
+++ b/igs-ecommerce-customizations/includes/class-translations.php
@@ -34,6 +34,20 @@ class Translations {
     private static array $cache = [];
 
     /**
+     * Clear the in-memory catalogue cache.
+     */
+    public static function flush_runtime_cache(): void {
+        self::$cache = [];
+    }
+
+    /**
+     * Retrieve the cache group used for object cache entries.
+     */
+    public static function get_cache_group(): string {
+        return self::CACHE_GROUP;
+    }
+
+    /**
      * Bootstrap the translation filters.
      */
     public static function init(): void {

--- a/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: IGS Ecommerce Customizations 1.3.0\n"
 "Report-Msgid-Bugs-To: https://ilgiardinosegreto.it/\n"
 "POT-Creation-Date: 2025-10-09 12:00+0000\n"
-"PO-Revision-Date: 2025-10-09 12:00+0000\n"
+"PO-Revision-Date: 2025-10-10 12:00+0000\n"
 "Last-Translator: Il Giardino Segreto <translations@example.com>\n"
 "Language-Team: Il Giardino Segreto <translations@example.com>\n"
 "Language: it\n"
@@ -527,3 +527,27 @@ msgstr "Impossibile determinare la versione di WooCommerce installata."
 #, php-format
 msgid "IGS Ecommerce Customizations richiede WooCommerce %1$s o superiore. Versione corrente: %2$s."
 msgstr "IGS Ecommerce Customizations richiede WooCommerce %1$s o superiore. Versione corrente: %2$s."
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:43
+#, php-format
+msgid "Cache dei tour ripulita per %d prodotti."
+msgstr "Cache dei tour ripulita per %d prodotti."
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:46
+#, php-format
+msgid "Eliminati %d transient di geocoding."
+msgstr "Eliminati %d transient di geocoding."
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:49
+#, php-format
+msgid "Eliminati %d transient di rate limiting."
+msgstr "Eliminati %d transient di rate limiting."
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:52
+#, php-format
+msgid "Ripuliti %d transient di traduzione."
+msgstr "Ripuliti %d transient di traduzione."
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:54
+msgid "Cache del plugin svuotate."
+msgstr "Cache del plugin svuotate."

--- a/igs-ecommerce-customizations/languages/igs-ecommerce.pot
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce.pot
@@ -524,3 +524,27 @@ msgstr ""
 #, php-format
 msgid "IGS Ecommerce Customizations richiede WooCommerce %1$s o superiore. Versione corrente: %2$s."
 msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:43
+#, php-format
+msgid "Cache dei tour ripulita per %d prodotti."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:46
+#, php-format
+msgid "Eliminati %d transient di geocoding."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:49
+#, php-format
+msgid "Eliminati %d transient di rate limiting."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:52
+#, php-format
+msgid "Ripuliti %d transient di traduzione."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/class-cli-commands.php:54
+msgid "Cache del plugin svuotate."
+msgstr ""


### PR DESCRIPTION
## Summary
- add a dedicated `igs flush-caches` WP-CLI command to clear tour, geocoding, rate limit and translation caches
- load the new CLI utilities only when WP-CLI is active and expose helpers to reset translation cache entries
- document the maintenance command and update translation catalogues

## Testing
- php -l igs-ecommerce-customizations/includes/class-cli-commands.php
- php -l igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php
- php -l igs-ecommerce-customizations/includes/class-translations.php

------
https://chatgpt.com/codex/tasks/task_e_68d504098908832f93e5c326129e9a64