### PR TITLE
Add regex support to global string replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Tutte le modifiche rilevanti del plugin **IGS Ecommerce Customizations** sono documentate in questo file.
 
+## [1.3.2] - 2025-09-26
+- Esteso il sistema di sostituzioni globali con supporto per regole regex, validando pattern e flag consentiti.
+- Aggiunta cache dei risultati delle sostituzioni per migliorare le prestazioni in produzione.
+- Aggiornate le istruzioni dell'interfaccia di amministrazione per documentare la sintassi delle regex.
+- Incrementata la versione del plugin a 1.3.2.
+
 ## [1.3.1] - 2025-09-25
 - Aggiornata la documentazione ufficiale con panoramica completa delle funzionalità e delle procedure operative.
 - Impostati i dati autore su Francesco Passeri con relativi riferimenti di contatto.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ambiente di produzione.
 
 ## Metadati del plugin
 
-- **Versione:** 1.3.1
+- **Versione:** 1.3.2
 - **Autore:** Francesco Passeri
 - **Sito web:** [francescopasseri.com](https://francescopasseri.com/)
 - **Email di riferimento:** [info@francescopasseri.com](mailto:info@francescopasseri.com)

--- a/igs-ecommerce-customizations/igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/igs-ecommerce-customizations.php
@@ -3,7 +3,7 @@
  * Plugin Name:       IGS Ecommerce Customizations
  * Plugin URI:        https://francescopasseri.com/
  * Description:       Raccolta di personalizzazioni per Il Giardino Segreto su WooCommerce.
- * Version:           1.3.1
+ * Version:           1.3.2
  * Author:            Francesco Passeri
  * Author URI:        https://francescopasseri.com/
  * Text Domain:       igs-ecommerce
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'IGS_ECOMMERCE_VERSION', '1.3.1' );
+define( 'IGS_ECOMMERCE_VERSION', '1.3.2' );
 define( 'IGS_ECOMMERCE_FILE', __FILE__ );
 define( 'IGS_ECOMMERCE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IGS_ECOMMERCE_URL', plugin_dir_url( __FILE__ ) );

--- a/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce-it_IT.po
@@ -199,7 +199,7 @@ msgstr "Regole di sostituzione testo"
 msgid "Regole"
 msgstr "Regole"
 
-#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:92
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:105
 msgid ""
 "Inserisci una regola per riga. Separa il testo originale dal nuovo testo con"
 " il carattere \"|\"."
@@ -207,11 +207,15 @@ msgstr ""
 "Inserisci una regola per riga. Separa il testo originale dal nuovo testo con"
 " il carattere \"|\"."
 
-#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:93
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:106
+msgid "Per usare le espressioni regolari, prefissa la regola con \"regex:\" e racchiudi il pattern tra slash, ad esempio regex:/prodotti/i."
+msgstr "Per usare le espressioni regolari, prefissa la regola con \"regex:\" e racchiudi il pattern tra slash, ad esempio regex:/prodotti/i."
+
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:107
 msgid "Esempio:"
 msgstr "Esempio:"
 
-#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:117
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:132
 msgid "Salva modifiche"
 msgstr "Salva modifiche"
 

--- a/igs-ecommerce-customizations/languages/igs-ecommerce.pot
+++ b/igs-ecommerce-customizations/languages/igs-ecommerce.pot
@@ -199,17 +199,21 @@ msgstr ""
 msgid "Regole"
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:92
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:105
 msgid ""
 "Inserisci una regola per riga. Separa il testo originale dal nuovo testo con"
 " il carattere \"|\"."
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:93
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:106
+msgid "Per usare le espressioni regolari, prefissa la regola con \"regex:\" e racchiudi il pattern tra slash, ad esempio regex:/prodotti/i."
+msgstr ""
+
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:107
 msgid "Esempio:"
 msgstr ""
 
-#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:117
+#: igs-ecommerce-customizations/includes/Admin/class-global-strings.php:132
 msgid "Salva modifiche"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- extend the global string replacement manager to support validated regex rules, cached results and escaped separators
- document the new syntax, update translations and bump the plugin version to 1.3.2
- record the enhancement in the changelog

## Testing
- php -l igs-ecommerce-customizations/includes/Admin/class-global-strings.php
- php -l igs-ecommerce-customizations/igs-ecommerce-customizations.php

------
https://chatgpt.com/codex/tasks/task_e_68d50c589a64832faaf38c3d203e0fef