### PR TITLE
Improve plural rule caching and bump version to 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Tutte le modifiche rilevanti del plugin **IGS Ecommerce Customizations** sono documentate in questo file.
 
+## [1.3.3] - 2025-09-27
+- Ottimizzato il calcolo runtime delle regole plurali nelle traduzioni per ridurre le valutazioni ripetute e garantire
+  fallback sicuri.
+- Svuotata anche la cache dei calcolatori dei plurali quando viene invalidata la cache delle traduzioni.
+
 ## [1.3.2] - 2025-09-26
 - Esteso il sistema di sostituzioni globali con supporto per regole regex, validando pattern e flag consentiti.
 - Aggiunta cache dei risultati delle sostituzioni per migliorare le prestazioni in produzione.

--- a/igs-ecommerce-customizations/igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/igs-ecommerce-customizations.php
@@ -3,7 +3,7 @@
  * Plugin Name:       IGS Ecommerce Customizations
  * Plugin URI:        https://francescopasseri.com/
  * Description:       Raccolta di personalizzazioni per Il Giardino Segreto su WooCommerce.
- * Version:           1.3.2
+ * Version:           1.3.3
  * Author:            Francesco Passeri
  * Author URI:        https://francescopasseri.com/
  * Text Domain:       igs-ecommerce
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'IGS_ECOMMERCE_VERSION', '1.3.2' );
+define( 'IGS_ECOMMERCE_VERSION', '1.3.3' );
 define( 'IGS_ECOMMERCE_FILE', __FILE__ );
 define( 'IGS_ECOMMERCE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IGS_ECOMMERCE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- optimise the runtime translation loader by caching compiled plural rule evaluators with safe fallbacks
- clear plural evaluator cache on translation cache flush and bump plugin metadata to version 1.3.3
- document the changes in the changelog

## Testing
- php -l igs-ecommerce-customizations/igs-ecommerce-customizations.php
- php -l igs-ecommerce-customizations/includes/class-translations.php

------
https://chatgpt.com/codex/tasks/task_e_68d51c180ff8832f972f6efb61b02a53