### PR TITLE
Add upgrade maintenance routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Tutte le modifiche rilevanti del plugin **IGS Ecommerce Customizations** sono do
 - Ottimizzato il calcolo runtime delle regole plurali nelle traduzioni per ridurre le valutazioni ripetute e garantire
   fallback sicuri.
 - Svuotata anche la cache dei calcolatori dei plurali quando viene invalidata la cache delle traduzioni.
+- Introdotte routine di upgrade automatiche che svuotano le cache persistenti dopo ogni aggiornamento del plugin.
 
 ## [1.3.2] - 2025-09-26
 - Esteso il sistema di sostituzioni globali con supporto per regole regex, validando pattern e flag consentiti.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ambiente di produzione.
 
 ## Metadati del plugin
 
-- **Versione:** 1.3.2
+- **Versione:** 1.3.3
 - **Autore:** Francesco Passeri
 - **Sito web:** [francescopasseri.com](https://francescopasseri.com/)
 - **Email di riferimento:** [info@francescopasseri.com](mailto:info@francescopasseri.com)
@@ -43,6 +43,8 @@ ambiente di produzione.
   database.
 - Rate limiting per le richieste di geocoding e per il form informazioni, con strumenti di monitoraggio tramite log e
   transients dedicati.
+- Routine di upgrade automatiche che svuotano le cache persistenti quando il plugin viene aggiornato, garantendo dati
+  coerenti senza interventi manuali.
 - Comando WP-CLI `wp igs flush-caches` per svuotare cache di tour, geocoding, rate limiting e traduzioni in ambienti con
   cache persistenti.
 - Migliorie sulla gestione email (fallback dell’indirizzo amministratore) e sui processi AJAX per minimizzare errori e

--- a/igs-ecommerce-customizations/includes/class-cli-commands.php
+++ b/igs-ecommerce-customizations/includes/class-cli-commands.php
@@ -7,8 +7,6 @@
 
 namespace IGS\Ecommerce;
 
-use IGS\Ecommerce\Helpers;
-
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -39,144 +37,13 @@ class CLI_Commands {
             return;
         }
 
-        $tour_count = self::flush_tour_cache();
-        \WP_CLI::log( sprintf( __( 'Cache dei tour ripulita per %d prodotti.', 'igs-ecommerce' ), $tour_count ) );
+        $summary = Maintenance::flush_all_caches();
 
-        $geocode_count = self::flush_geocode_caches();
-        \WP_CLI::log( sprintf( __( 'Eliminati %d transient di geocoding.', 'igs-ecommerce' ), $geocode_count ) );
-
-        $info_count = self::flush_info_rate_limit_caches();
-        \WP_CLI::log( sprintf( __( 'Eliminati %d transient di rate limiting.', 'igs-ecommerce' ), $info_count ) );
-
-        $translation_count = self::flush_translation_caches();
-        \WP_CLI::log( sprintf( __( 'Ripuliti %d transient di traduzione.', 'igs-ecommerce' ), $translation_count ) );
+        \WP_CLI::log( sprintf( __( 'Cache dei tour ripulita per %d prodotti.', 'igs-ecommerce' ), $summary['tour'] ) );
+        \WP_CLI::log( sprintf( __( 'Eliminati %d transient di geocoding.', 'igs-ecommerce' ), $summary['geocode'] ) );
+        \WP_CLI::log( sprintf( __( 'Eliminati %d transient di rate limiting.', 'igs-ecommerce' ), $summary['info'] ) );
+        \WP_CLI::log( sprintf( __( 'Ripuliti %d transient di traduzione.', 'igs-ecommerce' ), $summary['translations'] ) );
 
         \WP_CLI::success( __( 'Cache del plugin svuotate.', 'igs-ecommerce' ) );
-    }
-
-    /**
-     * Reset cached tour classification results.
-     */
-    private static function flush_tour_cache(): int {
-        global $igs_ecommerce_tour_cache;
-
-        if ( is_array( $igs_ecommerce_tour_cache ) ) {
-            $igs_ecommerce_tour_cache = [];
-        }
-
-        global $wpdb;
-
-        if ( ! isset( $wpdb->posts ) ) {
-            return 0;
-        }
-
-        $ids = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'product'" );
-
-        if ( empty( $ids ) ) {
-            return 0;
-        }
-
-        $ids    = array_map( 'intval', $ids );
-        $ids    = array_values( array_unique( $ids ) );
-        $count  = 0;
-
-        foreach ( $ids as $id ) {
-            wp_cache_delete( $id, Helpers\TOUR_PRODUCT_CACHE_GROUP );
-            $count++;
-        }
-
-        return $count;
-    }
-
-    /**
-     * Remove cached geocoding responses and rate limits.
-     */
-    private static function flush_geocode_caches(): int {
-        $total = 0;
-
-        $total += self::flush_prefixed_transients( 'igs_geocode_' );
-        $total += self::flush_prefixed_transients( 'igs_geocode_rl_' );
-
-        return $total;
-    }
-
-    /**
-     * Clear booking/info rate limiting windows.
-     */
-    private static function flush_info_rate_limit_caches(): int {
-        return self::flush_prefixed_transients( 'igs_info_rl_' );
-    }
-
-    /**
-     * Flush cached translation catalogues.
-     */
-    private static function flush_translation_caches(): int {
-        $count = self::flush_prefixed_transients( 'igs_translation_', true );
-        Translations::flush_runtime_cache();
-
-        return $count;
-    }
-
-    /**
-     * Delete transients with the provided prefix across single and multisite tables.
-     *
-     * @param string $prefix               Transient prefix, without the `_transient_` part.
-     * @param bool   $clear_translation_oc Whether to clear the translation object cache group.
-     */
-    private static function flush_prefixed_transients( string $prefix, bool $clear_translation_oc = false ): int {
-        $count = self::flush_transients_in_table( $prefix, false, $clear_translation_oc );
-
-        if ( is_multisite() ) {
-            $count += self::flush_transients_in_table( $prefix, true, $clear_translation_oc );
-        }
-
-        return $count;
-    }
-
-    /**
-     * Delete transients from a specific storage table.
-     */
-    private static function flush_transients_in_table( string $prefix, bool $network, bool $clear_translation_oc ): int {
-        global $wpdb;
-
-        $table  = $network ? $wpdb->sitemeta : $wpdb->options;
-        $column = $network ? 'meta_key' : 'option_name';
-        $pattern = $network ? '_site_transient_' : '_transient_';
-
-        if ( empty( $table ) ) {
-            return 0;
-        }
-
-        $like = $wpdb->esc_like( $pattern . $prefix ) . '%';
-        $sql  = $wpdb->prepare( "SELECT {$column} FROM {$table} WHERE {$column} LIKE %s", $like );
-        $rows = $wpdb->get_col( $sql );
-
-        if ( empty( $rows ) ) {
-            return 0;
-        }
-
-        $deleted = 0;
-
-        foreach ( $rows as $option_name ) {
-            if ( 0 !== strpos( $option_name, $pattern ) ) {
-                continue;
-            }
-
-            $key = substr( $option_name, strlen( $pattern ) );
-
-            if ( $network ) {
-                delete_site_transient( $key );
-            } else {
-                delete_transient( $key );
-            }
-
-            if ( $clear_translation_oc ) {
-                wp_cache_delete( $key, Translations::get_cache_group() );
-            }
-
-            $deleted++;
-        }
-
-        return $deleted;
     }
 }

--- a/igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php
+++ b/igs-ecommerce-customizations/includes/class-igs-ecommerce-customizations.php
@@ -54,9 +54,12 @@ final class Plugin {
     private function load_dependencies(): void {
         require_once IGS_ECOMMERCE_PATH . 'includes/class-translations.php';
         require_once IGS_ECOMMERCE_PATH . 'includes/helpers.php';
+        require_once IGS_ECOMMERCE_PATH . 'includes/class-maintenance.php';
+        require_once IGS_ECOMMERCE_PATH . 'includes/class-upgrades.php';
 
         Translations::init();
         Helpers\register_tour_product_cache_invalidation();
+        Upgrades::init();
 
         // Admin modules.
         require_once IGS_ECOMMERCE_PATH . 'includes/Admin/class-product-meta.php';

--- a/igs-ecommerce-customizations/includes/class-maintenance.php
+++ b/igs-ecommerce-customizations/includes/class-maintenance.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Shared maintenance utilities for cache and transient management.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS\Ecommerce;
+
+use IGS\Ecommerce\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Provide reusable maintenance helpers for CLI commands and upgrade routines.
+ */
+class Maintenance {
+    /**
+     * Flush all plugin related caches and return a summary.
+     *
+     * @return array{tour:int,geocode:int,info:int,translations:int}
+     */
+    public static function flush_all_caches(): array {
+        $summary = [
+            'tour'         => self::flush_tour_cache(),
+            'geocode'      => self::flush_geocode_caches(),
+            'info'         => self::flush_info_rate_limit_caches(),
+            'translations' => self::flush_translation_caches(),
+        ];
+
+        /**
+         * Fires after all plugin caches have been flushed.
+         *
+         * @param array{tour:int,geocode:int,info:int,translations:int} $summary Flush summary.
+         */
+        do_action( 'igs_after_flush_all_caches', $summary );
+
+        return $summary;
+    }
+
+    /**
+     * Reset cached tour classification results.
+     */
+    public static function flush_tour_cache(): int {
+        global $igs_ecommerce_tour_cache;
+
+        if ( is_array( $igs_ecommerce_tour_cache ) ) {
+            $igs_ecommerce_tour_cache = [];
+        }
+
+        global $wpdb;
+
+        if ( ! isset( $wpdb->posts ) ) {
+            return 0;
+        }
+
+        $ids = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'product'" );
+
+        if ( empty( $ids ) ) {
+            return 0;
+        }
+
+        $ids   = array_map( 'intval', $ids );
+        $ids   = array_values( array_unique( $ids ) );
+        $count = 0;
+
+        foreach ( $ids as $id ) {
+            wp_cache_delete( $id, Helpers\TOUR_PRODUCT_CACHE_GROUP );
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Remove cached geocoding responses and rate limits.
+     */
+    public static function flush_geocode_caches(): int {
+        $total = 0;
+
+        $total += self::flush_prefixed_transients( 'igs_geocode_' );
+        $total += self::flush_prefixed_transients( 'igs_geocode_rl_' );
+
+        return $total;
+    }
+
+    /**
+     * Clear booking/info rate limiting windows.
+     */
+    public static function flush_info_rate_limit_caches(): int {
+        return self::flush_prefixed_transients( 'igs_info_rl_' );
+    }
+
+    /**
+     * Flush cached translation catalogues.
+     */
+    public static function flush_translation_caches(): int {
+        $count = self::flush_prefixed_transients( 'igs_translation_', true );
+        Translations::flush_runtime_cache();
+
+        return $count;
+    }
+
+    /**
+     * Delete transients with the provided prefix across single and multisite tables.
+     *
+     * @param string $prefix               Transient prefix, without the `_transient_` part.
+     * @param bool   $clear_translation_oc Whether to clear the translation object cache group.
+     */
+    private static function flush_prefixed_transients( string $prefix, bool $clear_translation_oc = false ): int {
+        $count = self::flush_transients_in_table( $prefix, false, $clear_translation_oc );
+
+        if ( is_multisite() ) {
+            $count += self::flush_transients_in_table( $prefix, true, $clear_translation_oc );
+        }
+
+        return $count;
+    }
+
+    /**
+     * Delete transients from a specific storage table.
+     */
+    private static function flush_transients_in_table( string $prefix, bool $network, bool $clear_translation_oc ): int {
+        global $wpdb;
+
+        $table   = $network ? $wpdb->sitemeta : $wpdb->options;
+        $column  = $network ? 'meta_key' : 'option_name';
+        $pattern = $network ? '_site_transient_' : '_transient_';
+
+        if ( empty( $table ) ) {
+            return 0;
+        }
+
+        $like = $wpdb->esc_like( $pattern . $prefix ) . '%';
+        $sql  = $wpdb->prepare( "SELECT {$column} FROM {$table} WHERE {$column} LIKE %s", $like );
+        $rows = $wpdb->get_col( $sql );
+
+        if ( empty( $rows ) ) {
+            return 0;
+        }
+
+        $deleted = 0;
+
+        foreach ( $rows as $option_name ) {
+            if ( 0 !== strpos( $option_name, $pattern ) ) {
+                continue;
+            }
+
+            $key = substr( $option_name, strlen( $pattern ) );
+
+            if ( $network ) {
+                delete_site_transient( $key );
+            } else {
+                delete_transient( $key );
+            }
+
+            if ( $clear_translation_oc ) {
+                wp_cache_delete( $key, Translations::get_cache_group() );
+            }
+
+            $deleted++;
+        }
+
+        return $deleted;
+    }
+}

--- a/igs-ecommerce-customizations/includes/class-upgrades.php
+++ b/igs-ecommerce-customizations/includes/class-upgrades.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Handle plugin upgrade routines.
+ *
+ * @package IGS_Ecommerce_Customizations
+ */
+
+namespace IGS\Ecommerce;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Execute maintenance tasks when the plugin version changes.
+ */
+class Upgrades {
+    private const OPTION_VERSION = 'igs_ecommerce_version';
+
+    /**
+     * Register hooks used to detect and process upgrades.
+     */
+    public static function init(): void {
+        add_action( 'init', [ __CLASS__, 'maybe_run_upgrades' ], 1 );
+    }
+
+    /**
+     * Run upgrade routines when the stored version differs from the current one.
+     */
+    public static function maybe_run_upgrades(): void {
+        if ( ! defined( 'IGS_ECOMMERCE_VERSION' ) ) {
+            return;
+        }
+
+        $current_version = IGS_ECOMMERCE_VERSION;
+        $stored_version  = get_option( self::OPTION_VERSION, '' );
+
+        if ( ! is_string( $stored_version ) ) {
+            $stored_version = '';
+        }
+
+        if ( $stored_version === $current_version ) {
+            return;
+        }
+
+        // Skip expensive routines on the very first install.
+        if ( '' !== $stored_version ) {
+            $summary = Maintenance::flush_all_caches();
+
+            /**
+             * Fires after the plugin finished running its upgrade routines.
+             *
+             * @param string $stored_version  Previously stored version.
+             * @param string $current_version Current plugin version.
+             * @param array{tour:int,geocode:int,info:int,translations:int} $summary Cache flush summary.
+             */
+            do_action( 'igs_after_plugin_upgrade', $stored_version, $current_version, $summary );
+        }
+
+        update_option( self::OPTION_VERSION, $current_version );
+    }
+}


### PR DESCRIPTION
## Summary
- add shared maintenance helpers to flush plugin caches and reuse them from WP-CLI
- introduce an upgrade bootstrap that clears persistent caches when the plugin version changes
- document the new behaviour in the changelog and README

## Testing
- php -l igs-ecommerce-customizations/includes/class-maintenance.php
- php -l igs-ecommerce-customizations/includes/class-upgrades.php
- php -l igs-ecommerce-customizations/includes/class-cli-commands.php

------
https://chatgpt.com/codex/tasks/task_e_68d532b63170832f9e04e9471f358687